### PR TITLE
EEC-3 Add additional validation to ensure phone number begins with a digit or '+'

### DIFF
--- a/apps/eec/fields/index.js
+++ b/apps/eec/fields/index.js
@@ -5,7 +5,7 @@ const UANValidator = { type: 'regex', arguments: /^(\d{4}-\d{4}-\d{4}-\d{4})$/ }
 const BRPValidator = { type: 'regex', arguments: /^r[a-z](\d|X)\d{6}$/gi };
 const GWFValidator = { type: 'regex', arguments: /^gwf\d{9}$/gi };
 const UKVIValidator = { type: 'regex', arguments: /^KX.+$/i };
-const startsWithDigitOrPlus = { type: 'regex', arguments: /^[+\d].*$/ };
+const startsWithDigitOrPlus = { type: 'regex', arguments: /^[+\d].*\d$/ };
 
 /**
  * Validates that the given value only includes letters (a to z), spaces, hyphens, and apostrophes.

--- a/apps/eec/fields/index.js
+++ b/apps/eec/fields/index.js
@@ -5,7 +5,7 @@ const UANValidator = { type: 'regex', arguments: /^(\d{4}-\d{4}-\d{4}-\d{4})$/ }
 const BRPValidator = { type: 'regex', arguments: /^r[a-z](\d|X)\d{6}$/gi };
 const GWFValidator = { type: 'regex', arguments: /^gwf\d{9}$/gi };
 const UKVIValidator = { type: 'regex', arguments: /^KX.+$/i };
-const startsWithDigitOrPlus = { type: 'regex', arguments: /^[+\d].*$/ }
+const startsWithDigitOrPlus = { type: 'regex', arguments: /^[+\d].*$/ };
 
 /**
  * Validates that the given value only includes letters (a to z), spaces, hyphens, and apostrophes.

--- a/apps/eec/fields/index.js
+++ b/apps/eec/fields/index.js
@@ -5,6 +5,7 @@ const UANValidator = { type: 'regex', arguments: /^(\d{4}-\d{4}-\d{4}-\d{4})$/ }
 const BRPValidator = { type: 'regex', arguments: /^r[a-z](\d|X)\d{6}$/gi };
 const GWFValidator = { type: 'regex', arguments: /^gwf\d{9}$/gi };
 const UKVIValidator = { type: 'regex', arguments: /^KX.+$/i };
+const startsWithDigitOrPlus = { type: 'regex', arguments: /^[+\d].*$/ }
 
 /**
  * Validates that the given value only includes letters (a to z), spaces, hyphens, and apostrophes.
@@ -156,7 +157,7 @@ module.exports = {
   'detail-signin-phone': {
     mixin: 'input-text',
     className: ['govuk-input', 'govuk-!-width-one-third'],
-    validate: ['required', 'internationalPhoneNumber'],
+    validate: ['required', 'internationalPhoneNumber', startsWithDigitOrPlus],
     dependent: {
       field: 'problem',
       value: 'problem-signin-phone'

--- a/apps/eec/translations/src/en/validation.json
+++ b/apps/eec/translations/src/en/validation.json
@@ -32,7 +32,8 @@
   },
   "detail-signin-phone": {
     "required": "Enter the correct phone number where you can receive security codes",
-    "internationalPhoneNumber": "Enter a phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192"
+    "internationalPhoneNumber": "Enter a phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192",
+    "regex": "Enter a phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192"
   },
   "is-refugee": {
     "required": "Select if you have permission to stay in the UK as a refugee"


### PR DESCRIPTION
## What?

Added a validation to the `detail-signin-phone` field on page `/problem` to ensure that phone numbers added begin with a digit (0-9) or `+`. 

## Why?

This was raised as an issue as the existing validator allows any symbol to start the phone number. See comments in [EEC-3](https://collaboration.homeoffice.gov.uk/jira/browse/EEC-3).

Our standard validator looks for valid numbers from a GB perspective, and these may include non standard numbers or formats that are technically valid from a national or international viewpoint, but are not in the expected format. 

## How?

Added field validator

## Anything Else? (optional)

This validation can be removed if users report being unable to add a valid phone number according to their own country's format

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
