### PR TITLE
EEC-22: Remove extra space

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,7 @@ environment:
   UAT_ENV: sas-eec-uat
   STG_ENV: sas-eec-stg
   PROD_ENV: sas-eec-prod
-  PRODUCTION_URL:  www.report-error-evisa.homeoffice.gov.uk
+  PRODUCTION_URL: www.report-error-evisa.homeoffice.gov.uk
   IMAGE_URL: 340268328991.dkr.ecr.eu-west-2.amazonaws.com
   IMAGE_REPO: sas/eec
   GIT_REPO: UKHomeOffice/evisa-error-correction


### PR DESCRIPTION
## What?

* double spacing is fixed
* This can lead to issues in future

## Why?

* This prod url will be replaced in the kubernetes scripts during drone build, can lead to issues like policy admissions


## How?

* Remove the extra space before url

## Testing?

## Screenshots (optional)

## Anything Else? (optional)

## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
