### PR TITLE
EEC-45/46: Added '/in-uk' and '/viewing-evisa' pages

### DIFF
--- a/apps/eec/behaviours/submit-request.js
+++ b/apps/eec/behaviours/submit-request.js
@@ -48,12 +48,15 @@ module.exports = superclass => class extends superclass {
 
     try {
       businessEmailProps.addPersonalisation({
+        in_uk: getLabel('in-uk', req.sessionModel.get('in-uk')),
+        is_not_viewing_evisa: req.sessionModel.get('viewing-evisa') === 'no' ? 'yes' : 'no',
+        viewing_evisa: getLabel('viewing-evisa', req.sessionModel.get('viewing-evisa')),
         full_name: req.sessionModel.get('requestor-full-name'),
         date_of_birth: formatDate(req.sessionModel.get('requestor-dob')),
         nationality: req.sessionModel.get('requestor-nationality'),
         reference: req.sessionModel.get('formatted-reference'),
         is_refugee: getLabel('is-refugee', req.sessionModel.get('is-refugee')),
-        problem_notes: buildProblemNotes(req),
+        problem_notes: req.sessionModel.get('viewing-evisa') === 'no' ? buildProblemNotes(req) : '',
         contact_email: req.sessionModel.get('requestor-contact-method') === 'email' ?
           req.sessionModel.get('requestor-email') : 'none provided',
         contact_address: req.sessionModel.get('requestor-contact-method') === 'uk-address' ?

--- a/apps/eec/fields/index.js
+++ b/apps/eec/fields/index.js
@@ -28,6 +28,40 @@ function validateText(value) {
 }
 
 module.exports = {
+  'in-uk': {
+    isPageHeading: 'true',
+    mixin: 'radio-group',
+    className: ['govuk-radios', 'govuk-radios--inline'],
+    validate: 'required',
+    options: [
+      {
+        value: 'yes'
+      },
+      {
+        value: 'no'
+      }
+    ],
+    legend: {
+      className: 'govuk-!-margin-bottom-6'
+    }
+  },
+  'viewing-evisa': {
+    isPageHeading: 'true',
+    mixin: 'radio-group',
+    className: ['govuk-radios', 'govuk-radios--inline'],
+    validate: 'required',
+    options: [
+      {
+        value: 'yes'
+      },
+      {
+        value: 'no'
+      }
+    ],
+    legend: {
+      className: 'govuk-!-margin-bottom-6'
+    }
+  },
   problem: {
     mixin: 'checkbox-group',
     validate: ['required'],

--- a/apps/eec/index.js
+++ b/apps/eec/index.js
@@ -9,6 +9,25 @@ module.exports = {
   params: '/:action?/:id?/:edit?',
   confirmStep: '/check-answers',
   steps: {
+    '/in-uk': {
+      next: '/viewing-evisa',
+      fields: ['in-uk'],
+      showNeedHelp: true
+    },
+    '/viewing-evisa': {
+      next: '/problem',
+      fields: ['viewing-evisa'],
+      showNeedHelp: true,
+      forks: [
+        {
+          target: '/personal-details',
+          condition: {
+            field: 'viewing-evisa',
+            value: 'yes'
+          }
+        }
+      ]
+    },
     '/problem': {
       next: '/personal-details',
       fields: [

--- a/apps/eec/sections/summary-data-sections.js
+++ b/apps/eec/sections/summary-data-sections.js
@@ -1,43 +1,64 @@
 const { getLabel, formatDate } = require('../../../utils');
 
+function isViewingEvisa(req) {
+  return req.sessionModel.get('viewing-evisa') === 'yes';
+}
+
 module.exports = {
   'corrected-details': {
     steps: [
       {
-        step: '/problem',
-        field: 'detail-full-name'
+        step: '/in-uk',
+        field: 'in-uk'
+      },
+      {
+        step: '/viewing-evisa',
+        field: 'viewing-evisa'
       },
       {
         step: '/problem',
-        field: 'detail-sponsor-ref'
+        field: 'detail-full-name',
+        parse: (val, req) => isViewingEvisa(req) ? '' : val
       },
       {
         step: '/problem',
-        field: 'detail-photo'
+        field: 'detail-sponsor-ref',
+        parse: (val, req) => isViewingEvisa(req) ? '' : val
       },
       {
         step: '/problem',
-        field: 'detail-nin'
+        field: 'detail-photo',
+        parse: (val, req) => isViewingEvisa(req) ? '' : val
       },
       {
         step: '/problem',
-        field: 'detail-restrictions'
+        field: 'detail-nin',
+        parse: (val, req) => isViewingEvisa(req) ? '' : val
       },
       {
         step: '/problem',
-        field: 'detail-status'
+        field: 'detail-restrictions',
+        parse: (val, req) => isViewingEvisa(req) ? '' : val
       },
       {
         step: '/problem',
-        field: 'detail-valid-until'
+        field: 'detail-status',
+        parse: (val, req) => isViewingEvisa(req) ? '' : val
       },
       {
         step: '/problem',
-        field: 'detail-signin-email'
+        field: 'detail-valid-until',
+        parse: (val, req) => isViewingEvisa(req) ? '' : val
       },
       {
         step: '/problem',
-        field: 'detail-signin-phone'
+        field: 'detail-signin-email',
+        parse: (val, req) => isViewingEvisa(req) ? '' : val
+      },
+      {
+        step: '/problem',
+        field: 'detail-signin-phone',
+        parse: (val, req) => isViewingEvisa(req) ? '' : val
       }
     ]
   },

--- a/apps/eec/translations/src/en/fields.json
+++ b/apps/eec/translations/src/en/fields.json
@@ -1,4 +1,26 @@
 {
+  "in-uk": {
+    "legend": "Are you currently in the UK?",
+    "options": {
+      "yes": {
+          "label": "Yes"
+      },
+      "no": {
+          "label": "No"
+      }
+    }
+  },
+  "viewing-evisa": {
+    "legend": "Are you having problems viewing your eVisa?",
+    "options": {
+      "yes": {
+          "label": "Yes, I cannot see my eVisa when I sign in to my UKVI account"
+      },
+      "no": {
+          "label": "No, the problem is something else"
+      }
+    }
+  },
   "problem": {
     "legend": "What is the problem with your eVisa?",
     "hint": "You can select more than one option",

--- a/apps/eec/translations/src/en/pages.json
+++ b/apps/eec/translations/src/en/pages.json
@@ -36,6 +36,12 @@
       }
     },
     "fields": {
+      "in-uk": {
+        "label": "In UK"
+      },
+      "viewing-evisa": {
+        "label": "Problem viewing eVisa"
+      },
       "detail-full-name": {
         "label": "Full name"
       },

--- a/apps/eec/translations/src/en/validation.json
+++ b/apps/eec/translations/src/en/validation.json
@@ -1,4 +1,10 @@
 {
+  "in-uk": {
+    "required": "Select if you are currently in the UK"
+  },
+  "viewing-evisa": {
+    "required": "Select if you are having problems viewing your eVisa"
+  },
   "problem": {
     "required": "Select what the problem is"
   },

--- a/test/unit/submit-request.test.js
+++ b/test/unit/submit-request.test.js
@@ -50,6 +50,8 @@ describe('submit-feedback behaviour', () => {
 
       req.sessionModel = new Model({
         problem: ['problem-photo', 'problem-nin'],
+        'in-uk': 'yes',
+        'viewing-evisa': 'no',
         'detail-photo': 'photo bad',
         'detail-nin': 'QQ123456A',
         'requestor-full-name': 'test user',
@@ -99,6 +101,9 @@ describe('submit-feedback behaviour', () => {
     test('Notify sendEmail to business is called with the correct props', async () => {
       emailProps = {
         personalisation: {
+          in_uk: 'Yes',
+          is_not_viewing_evisa: 'yes',
+          viewing_evisa: 'No, the problem is something else',
           full_name: 'test user',
           date_of_birth: '14/08/1987',
           nationality: 'France',
@@ -127,6 +132,9 @@ describe('submit-feedback behaviour', () => {
 
       emailProps = {
         personalisation: {
+          in_uk: 'Yes',
+          is_not_viewing_evisa: 'yes',
+          viewing_evisa: 'No, the problem is something else',
           full_name: 'test user',
           date_of_birth: '14/08/1987',
           nationality: 'France',
@@ -152,6 +160,9 @@ describe('submit-feedback behaviour', () => {
 
       emailProps = {
         personalisation: {
+          in_uk: 'Yes',
+          is_not_viewing_evisa: 'yes',
+          viewing_evisa: 'No, the problem is something else',
           full_name: 'test user',
           date_of_birth: '14/08/1987',
           nationality: 'France',


### PR DESCRIPTION
## What?
New pages have been added at the beginning of the form with the conditional journey;
The summary page and email notification have also been updated to reflect the changes;

[EEC-45](https://collaboration.homeoffice.gov.uk/jira/browse/EEC-45) - EEC: Create an "Are you currently in the UK" page
[EEC-46](https://collaboration.homeoffice.gov.uk/jira/browse/EEC-46) - EEC: Create an "Are you having problems viewing your eVisa" page

## Why?

## How?

## Testing?

## Screenshots (optional)

## Anything Else? (optional)

## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
