### PR TITLE
EEC-59: Evisa Route change

### DIFF
--- a/apps/eec/index.js
+++ b/apps/eec/index.js
@@ -20,13 +20,17 @@ module.exports = {
       showNeedHelp: true,
       forks: [
         {
-          target: '/personal-details',
+          target: '/before-reporting',
           condition: {
             field: 'viewing-evisa',
             value: 'yes'
           }
         }
       ]
+    },
+    '/before-reporting': {
+      next: '/personal-details',
+      showNeedHelp: true
     },
     '/problem': {
       next: '/personal-details',

--- a/apps/eec/translations/src/en/buttons.json
+++ b/apps/eec/translations/src/en/buttons.json
@@ -2,5 +2,6 @@
   "edit": "Change",
   "continue": "Continue",
   "submit": "Submit request",
-  "finish-and-return": "Finish and return to GOV.UK"
+  "finish-and-return": "Finish and return to GOV.UK",
+  "continue-to-report-an-error": "Continue to report an error"
 }

--- a/apps/eec/translations/src/en/pages.json
+++ b/apps/eec/translations/src/en/pages.json
@@ -1,4 +1,14 @@
 {
+  "before-reporting": {
+    "header": "Before you report an error with your eVisa",
+    "check-three-steps-for-access": "Check that you have completed the 3 steps to get <a href='https://www.gov.uk/get-access-evisa'>get access to your eVisa</a>.",
+    "step1": "Create a UKVI account",
+    "step2": "Confirm your identity",
+    "step3": "Link your eVisa to your account",
+    "once-you-have-access": "Once you have access to your eVisa, you can sign in to your UKVI account to <a href='https://www.gov.uk/view-prove-immigration-status'>view your eVisa and prove your immigration status</a>.",
+    "header2": "If you cannot get into your account",
+    "get-help": "Get help if you're having <a href='https://update-your-details.homeoffice.gov.uk/account-recovery/help'>problems signing into your account</a>."
+  }, 
   "personal-details": {
     "header": "Personal details",
     "intro": "You must enter these details exactly as they appear on your eVisa so we can review the problem."

--- a/apps/eec/views/before-reporting.html
+++ b/apps/eec/views/before-reporting.html
@@ -1,0 +1,15 @@
+{{<partials-page}}
+  {{$page-content}}
+    <p class="govuk-body">{{#t}}pages.before-reporting.check-three-steps-for-access{{/t}}</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>{{#t}}pages.before-reporting.step1{{/t}}</li>
+      <li>{{#t}}pages.before-reporting.step2{{/t}}</li>
+      <li>{{#t}}pages.before-reporting.step3{{/t}}</li>
+    </ul>
+    <p class="govuk-body">{{#t}}pages.before-reporting.once-you-have-access{{/t}}</p>
+    <h2 class="govuk-heading-m">{{#t}}pages.before-reporting.header2{{/t}}</h2>
+
+    <p class="govuk-body">{{#t}}pages.before-reporting.get-help{{/t}}</p>
+    {{#input-submit}}continue-to-report-an-error{{/input-submit}}
+  {{/page-content}}
+{{/partials-page}}


### PR DESCRIPTION
## What?
CREATE NEW PAGE - 'Before you report an error with your e-visa' (Accessing evisa route change)

## Why?
https://collaboration.homeoffice.gov.uk/jira/browse/EEC-59

## How?
- updated routes from `/viewing-evisa` page (index.js)
- added `/before-reporting` route (index.js)
- added text to translation library for `/before-reporting` (pages.json)
- created new template for `/before-reporting` (before-reporting.html)
- added continue button to match design for page (buttons.json)

## Testing?

### /viewing-evisa
from this page, 
  - selecting 'no' will take you directly to `/problem`.  
  - selecting yes will take you to the new `/before-reporting` (see screenshot below)

![image](https://github.com/user-attachments/assets/7586af6b-c2b3-4094-abe3-069cb63d0dfb)

### /before-reporting
this page should meet all the acceptance criteria at https://collaboration.homeoffice.gov.uk/jira/browse/EEC-59.  
Once finished reading selecting the green `Continue to report an error` button should take you to `/problem`
![image](https://github.com/user-attachments/assets/24584db7-b068-4ae2-8bc3-c1d6115ad69e)

## Screenshots (optional)

## Anything Else? (optional)

## Check list
- [X] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [X]  I have created a JIRA number for my branch
- [X] I have created a JIRA number for my commit
- [X]  I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [X] Ensure drone builds are green especially tests
- [X] I will squash the commits before merging