### PR TITLE
EEC-63: Change content for Request Sent page

### DIFF
--- a/apps/eec/views/content/en/what-happens-next.md
+++ b/apps/eec/views/content/en/what-happens-next.md
@@ -4,4 +4,4 @@ If you provided your email address we will send you an email to confirm that we 
 
 We will review the information you have provided to correct your eVisa.
 
-We will contact you to confirm when we have corrected the details, or to let you know if we need more information. This can take up to 10 working days.
+We will contact you to confirm when we have corrected the details, or to let you know if we need more information.


### PR DESCRIPTION
## What?
Updated text for Request Sent page

## Why?
https://collaboration.homeoffice.gov.uk/jira/browse/EEC-63

## How?
- removed text from string (what-happens-next.md)

## Testing?
After completing the user journey and submitting the form, the final paragraph on `/request-sent` should read only, "We will contact you to confirm when we have corrected the details, or to let you know if we need more information."  It should not not contain the text "This can take up to 10 working days."  

<img width="1100" alt="image" src="https://github.com/user-attachments/assets/0fe3479b-7eb4-4f00-9717-6129a713dc5a" />


## Screenshots (optional)

## Anything Else? (optional)

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
