### PR TITLE
EEC-72: Increase allocated memory to eec container

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -189,6 +189,7 @@ steps:
     depends_on:
       - linting
       - unit_tests
+      - build_image
 
   # Trivy Security Scannner for scanning nodejs packages in Yarn
   - name: scan_node_packages

--- a/kube/app/deployment.yml
+++ b/kube/app/deployment.yml
@@ -96,10 +96,10 @@ spec:
           resources:
             requests:
               cpu: "20m"
-              memory: "100Mi"
+              memory: "256Mi"
             limits:
               cpu: "100m"
-              memory: "200Mi"
+              memory: "512Mi"
           volumeMounts:
             - mountPath: /public
               name: public


### PR DESCRIPTION
## What?

* Pods with eec container have been restarted for 6 time in 2 weeks
* Pods killed with OOM.
* Highest consumption of the memory was 234 MiB which is beyond the memory limit i.e 200 MiB
* None of Application issues identified.
* Sysdig screenshots added to the Jira ticket
* https://collaboration.homeoffice.gov.uk/jira/browse/EEC-72

## Why?

*  Pods are terminated and restarted, which causes temporary unavailability.
* On a node with limited memory, an OOM-killed pod can affect other pods by consuming shared resources.
* It may trigger node instability or evictions of other pods.


## How?

* By increasing the memory limits to 512 MiB and memory requests to 256 MiB, we can ensure the pod has sufficient memory headroom to operate under normal and slightly elevated workloads without being OOM-killed, thereby improving stability, reducing restarts, and enhancing overall application reliability.

## Testing?

* Inspect the Memory usage of the pod. 
* Montior using Sysdig Dashboard. 
* Ensure the pod memory limits and requests have been changed to the latest values.

## Screenshots (optional)

Please refer to the screenshots added to the jira ticket

## Anything Else? (optional)

## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
