### PR TITLE
EEC-77: Deindex EEC

### DIFF
--- a/.devcontainer/devcontainer.env.sample
+++ b/.devcontainer/devcontainer.env.sample
@@ -8,3 +8,6 @@ REDIS_HOST=hof-redis
 #BUSINESS_CONFIRMATION_TEMPLATE_ID=
 #USER_CONFIRMATION_TEMPLATE_ID=
 #EMAIL_REPLY_TO_ID=
+
+# Prevent all pages from being indexed by search engines
+DISALLOW_INDEXING="true"

--- a/apps/eec/index.js
+++ b/apps/eec/index.js
@@ -2,6 +2,15 @@ const hof = require('hof');
 const Summary = hof.components.summary;
 const submitRequest = require('./behaviours/submit-request');
 const validateAutocomplete = require('./behaviours/validate-autocomplete');
+const { disallowIndexing } = require('../../config');
+
+const pages = {
+  '/accessibility': 'static/accessibility'
+};
+
+if (disallowIndexing) {
+  pages['/robots.txt'] = 'static/robots';
+}
 
 module.exports = {
   name: 'eec',
@@ -134,7 +143,5 @@ module.exports = {
       backLink: false
     }
   },
-  pages: {
-    '/accessibility': 'static/accessibility'
-  }
+  pages: pages
 };

--- a/apps/eec/views/layout.html
+++ b/apps/eec/views/layout.html
@@ -1,6 +1,11 @@
 {{<govuk-template}}
   {{$head}}
     {{> partials-head}}
+
+    {{#disallowIndexing}}
+      {{> partials-disallow-indexing}}
+    {{/disallowIndexing}}
+
   {{/head}}
   {{$pageTitle}}
     {{#errorlist.length}}{{#t}}errorlist.prefix{{/t}}{{/errorlist.length}} {{title}} &ndash; {{#t}}journey.serviceName{{/t}} &ndash; GOV.UK

--- a/apps/eec/views/partials/disallow-indexing.html
+++ b/apps/eec/views/partials/disallow-indexing.html
@@ -1,0 +1,1 @@
+<meta name="robots" content="noindex">

--- a/apps/eec/views/static/robots.html
+++ b/apps/eec/views/static/robots.html
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/config.js
+++ b/config.js
@@ -21,5 +21,6 @@ module.exports = {
   redis: {
     port: process.env.REDIS_PORT || '6379',
     host: process.env.REDIS_HOST || '127.0.0.1'
-  }
+  },
+  disallowIndexing: process.env.DISALLOW_INDEXING === 'true'
 };

--- a/kube/app/deployment.yml
+++ b/kube/app/deployment.yml
@@ -79,6 +79,9 @@ spec:
                   key: notify-key
             - name: USE_MOCKS
               value: "false"
+            # Preventing search engines from indexing all pages
+            - name: DISALLOW_INDEXING
+              value: "true"
           {{ if not (eq .KUBE_NAMESPACE .BRANCH_ENV) }}
           livenessProbe:
             httpGet:

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@
 const hof = require('hof');
 
 let settings = require('./hof.settings');
+const config = require('./config');
 
 settings = Object.assign({}, settings, {
   behaviours: settings.behaviours.map(require),
@@ -13,6 +14,7 @@ const app = hof(settings);
 
 app.use((req, res, next) => {
   res.locals.htmlLang = 'en';
+  res.locals.disallowIndexing = config.disallowIndexing;
   next();
 });
 


### PR DESCRIPTION
## What?
Updating EEC site to prevent search engine indexing

## Why?
https://collaboration.homeoffice.gov.uk/jira/browse/EEC-77

## How?
- added disallowIndexing variable (config.js, server.js, devcontainer.env.sample, index.js, deployment.yml)
- created partial template with noindex meta tag (disallow-indexing.html)
- conditionally added noindex partial template to main html template (layout.html)
- created top level file to disallow index (robots.html)
- conditionally declaring/creating robots.txt (index.js)
- minor formatting change (index.js)

## Testing?
Every page in the build should have a metatag within its head containing `<meta name="robots" content="noindex">`.  

Note this does not currently include the Cookies and "Terms and Conditions" pages, which will need to be updated from the HOF Framework itself.  

## Screenshots (optional)
![image](https://github.com/user-attachments/assets/94ac5c16-4f90-43e7-952b-b2ad87c3dfd1)

## Anything Else? (optional)

## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
