### PR TITLE
EEC-91: Fix Drone pipeline issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 FROM node:20.18.0-alpine3.20@sha256:d504f23acdda979406cf3bdbff0dff7933e5c4ec183dda404ed24286c6125e60
 USER root
 
-# Update the package index and upgrade all installed packages to their latest versions
-RUN apk update && apk upgrade
+# Switch to UK Alpine mirrors, install bash, update package index, and upgrade all installed packages
+RUN echo "http://uk.alpinelinux.org/alpine/v3.21/main" > /etc/apk/repositories ; \
+    echo "http://uk.alpinelinux.org/alpine/v3.21/community" >> /etc/apk/repositories ; \
+    apk add --no-cache bash ; \
+    apk update && apk upgrade --no-cache
 
 # Setup nodejs group & nodejs user
 RUN addgroup --system nodejs --gid 998 && \


### PR DESCRIPTION
## What? 
This Fix has been succesfully tested on CSL. This is same issue  now in EEC as the steps are running same commands causing network outage
**Pipeline Optimization Update**
After comparing the pipeline with other services, we identified that the Build_Image and image_to_ecr Drone steps were running in parallel.
Since both steps involve image building and pushing, this parallel execution led to high memory consumption, increased network traffic, and elevated CPU usage.
To address this, these steps will now be executed sequentially, reducing resource contention and improving overall pipeline stability.

**UK Mirror Optimization**
Switched to a UK-based Alpine Linux mirror.
Reduces latency for package downloads.
Speeds up image builds in UK-hosted environments.
Improves reliability and consistency in CI/CD pipelines.
We’ve also updated the base image configuration to use a UK-based Alpine Linux mirror.
This change significantly improves package download speeds and reduces latency during image builds, especially in UK-hosted environments or CI runners.
https://collaboration.homeoffice.gov.uk/jira/browse/EEC-91

## Why? 
* Builds are failing in EEC. Since this is only issue with EEC. We expect the issue is in our pipeline 
* We still use same base image 
* This issue is blocking dev work as most of the builds failed


## How? 

* The image_to_ecr step in the Drone pipeline now includes a depends_on directive to explicitly wait for the build_image  step to complete.
* Switched to a UK-based Alpine Linux mirror.



## Testing?

Run pipeline for 5 times and confirm these are working and request devs to test their pipeline with these changes.
## Screenshots (optional)



## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)


