### PR TITLE
EEC-96: Validation and content changed for travel document number. Al…

### DIFF
--- a/apps/eec/fields/index.js
+++ b/apps/eec/fields/index.js
@@ -76,12 +76,12 @@ module.exports = {
     }
   }),
   'travel-doc-number': {
-    className: ['govuk-input', 'govuk-input--width-10'],
+    className: ['govuk-input', 'govuk-input--width-20'],
     validate: [
       'required',
       'alphanum',
-      { type: 'minlength', arguments: 9 },
-      { type: 'maxlength', arguments: 13 }
+      { type: 'minlength', arguments: 1 },
+      { type: 'maxlength', arguments: 22 }
     ]
   },
   'travel-doc-nationality': {

--- a/apps/eec/translations/src/en/validation.json
+++ b/apps/eec/translations/src/en/validation.json
@@ -12,8 +12,8 @@
   "travel-doc-number": {
     "required": "Enter your document number",
     "alphanum": "Document number must only include numbers and letters",
-    "minlength": "Document number must be between 9 and 13 characters",
-    "maxlength": "Document number must be between 9 and 13 characters"
+    "minlength": "Document number must be between 1 and 22 characters",
+    "maxlength": "Document number must be between 1 and 22 characters"
   },
   "travel-doc-nationality": {
     "required": "Enter your country of nationality",


### PR DESCRIPTION
…so increased width of the input text box.

## What?
Changed validation and error message to 'Document number must be between 1 and 22 characters' for travel document number.
Increased width of the input text box to accommodate new max length 22.
  
## Why?
[EEC-96](https://collaboration.homeoffice.gov.uk/jira/browse/EEC-96)

## How?
Changed validation minlength, maxlength and classname in apps/eec/fields/index.js
Changed error messages in apps/eec/translations/src/en/validation.json

## Testing?
Manual testing conducted.

## Screenshots (optional)

## Anything Else? (optional)

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
