### PR TITLE
HOFF-2068-EVC-PVC-Correction

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.18.0-alpine3.20@sha256:d504f23acdda979406cf3bdbff0dff7933e5c4ec183dda404ed24286c6125e60
+FROM quay.io/ukhomeofficedigital/hof-nodejs:20.20.2-alpine3.23@sha256:bcd17b68a0f1910f1670b07f6a47d1e2c28291bafc219807c494dc62b57ea25e
 
 USER root
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,8 +3,8 @@ FROM quay.io/ukhomeofficedigital/hof-nodejs:20.20.2-alpine3.23@sha256:bcd17b68a0
 USER root
 
 # Switch to UK Alpine mirrors, update package index and upgrade all installed packages
-RUN echo "http://uk.alpinelinux.org/alpine/v3.20/main" > /etc/apk/repositories ; \
-    echo "http://uk.alpinelinux.org/alpine/v3.20/community" >> /etc/apk/repositories ; \
+RUN echo "http://uk.alpinelinux.org/alpine/v3.23/main" > /etc/apk/repositories ; \
+    echo "http://uk.alpinelinux.org/alpine/v3.23/community" >> /etc/apk/repositories ; \
     apk update && apk upgrade --no-cache
 
 # Setup nodejs group & nodejs user

--- a/.drone.yml
+++ b/.drone.yml
@@ -47,7 +47,7 @@ trivy-client-image: &trivy-client-image
 
 node_image: &node_image
   pull: if-not-exists
-  image: node:20.18.0-alpine3.20@sha256:d504f23acdda979406cf3bdbff0dff7933e5c4ec183dda404ed24286c6125e60
+  image: quay.io/ukhomeofficedigital/hof-nodejs:20.20.2-alpine3.23@sha256:bcd17b68a0f1910f1670b07f6a47d1e2c28291bafc219807c494dc62b57ea25e
 
 linting: &linting
   <<: *node_image
@@ -113,7 +113,7 @@ steps:
         cpu: 1000
         memory: 1024Mi
     environment:
-      IMAGE_NAME: node:20.18.0-alpine3.20@sha256:d504f23acdda979406cf3bdbff0dff7933e5c4ec183dda404ed24286c6125e60
+      IMAGE_NAME: quay.io/ukhomeofficedigital/hof-nodejs:20.20.2-alpine3.23@sha256:bcd17b68a0f1910f1670b07f6a47d1e2c28291bafc219807c494dc62b57ea25e
       SERVICE_URL: https://acp-trivy-helm.acp-trivy.svc.cluster.local:443
       SEVERITY: MEDIUM,HIGH,CRITICAL --dependency-tree
       FAIL_ON_DETECTION: false
@@ -420,7 +420,7 @@ steps:
   - name: cron_trivy_scan_image_os
     <<: *trivy-client-image
     environment:
-        IMAGE_NAME: node:20.18.0-alpine3.20@sha256:d504f23acdda979406cf3bdbff0dff7933e5c4ec183dda404ed24286c6125e60
+        IMAGE_NAME: quay.io/ukhomeofficedigital/hof-nodejs:20.20.2-alpine3.23@sha256:bcd17b68a0f1910f1670b07f6a47d1e2c28291bafc219807c494dc62b57ea25e
         SEVERITY: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL --dependency-tree
         FAIL_ON_DETECTION: true
         IGNORE_UNFIXED: false

--- a/.drone.yml
+++ b/.drone.yml
@@ -117,7 +117,7 @@ steps:
       SERVICE_URL: https://acp-trivy-helm.acp-trivy.svc.cluster.local:443
       SEVERITY: MEDIUM,HIGH,CRITICAL --dependency-tree
       FAIL_ON_DETECTION: false
-      IGNORE_UNFIXED: false
+      IGNORE_UNFIXED: true
       ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
     volumes:
       - name: dockersock

--- a/.drone.yml
+++ b/.drone.yml
@@ -216,7 +216,7 @@ steps:
       IMAGE_NAME: sas/eec:${DRONE_COMMIT_SHA}
       SEVERITY: MEDIUM,HIGH,CRITICAL --dependency-tree
       FAIL_ON_DETECTION: false
-      IGNORE_UNFIXED: false
+      IGNORE_UNFIXED: true
       ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
     volumes:
       - name: dockersock

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM quay.io/ukhomeofficedigital/hof-nodejs:20.20.2-alpine3.23@sha256:bcd17b68a0
 USER root
 
 # Switch to UK Alpine mirrors, update package index and upgrade all installed packages
-RUN echo "http://uk.alpinelinux.org/alpine/v3.20/main" > /etc/apk/repositories ; \
-    echo "http://uk.alpinelinux.org/alpine/v3.20/community" >> /etc/apk/repositories ; \
+RUN echo "http://uk.alpinelinux.org/alpine/v3.23/main" > /etc/apk/repositories ; \
+    echo "http://uk.alpinelinux.org/alpine/v3.23/community" >> /etc/apk/repositories ; \
     apk update && apk upgrade --no-cache
 
 # Setup nodejs group & nodejs user

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.18.0-alpine3.20@sha256:d504f23acdda979406cf3bdbff0dff7933e5c4ec183dda404ed24286c6125e60
+FROM quay.io/ukhomeofficedigital/hof-nodejs:20.20.2-alpine3.23@sha256:bcd17b68a0f1910f1670b07f6a47d1e2c28291bafc219807c494dc62b57ea25e
 USER root
 
 # Switch to UK Alpine mirrors, update package index and upgrade all installed packages

--- a/kube/redis/redis-deployment.yml
+++ b/kube/redis/redis-deployment.yml
@@ -9,6 +9,8 @@ metadata:
   {{ end }}
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}


### PR DESCRIPTION
## What?
This pull request makes a small but important change to the Redis deployment configuration. The deployment strategy is now explicitly set to `Recreate`, which ensures that all existing pods are terminated before new ones are created during updates.

* Set the deployment `strategy` to `Recreate` in `redis-deployment.yml` to avoid issues with multiple Redis pods running simultaneously.

## Why?
To prevent 
`Warning  FailedAttachVolume  4m40s                attachdetach-controller  Multi-Attach error for volume "pvc-925ebb44-8f88-45d3-8c58-8a33cef9294f" Volume is already used by pod(s) redis-node-pvc-fix-6bd7dc8d8d-9qjx8
  Warning  FailedMount         20s (x2 over 2m37s)  kubelet                  Unable to attach or mount volumes: unmounted volumes=[data], unattached volumes=[data default-token-rgpgj]: timed out waiting for the condition `

## How?
Change the strategy in redis deploy

## Testing?
Manual - delete and redeploy pod

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
