### PR TITLE
EEC-179: added new drone step to deploy to UAT on merge to  eec-phase-4-release

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -36,6 +36,11 @@ include_default_and_feature_branches: &include_default_and_feature_branches
   include:
     - master
     - feature/*
+    - eec-phase-4-release
+
+include_eec_phase_4_release_branch: &include_eec_phase_4_release_branch
+  include:
+    - eec-phase-4-release
 
 trigger:
   branch:
@@ -259,6 +264,25 @@ steps:
     when:
       branch:
         <<: *include_default_branch
+      event: push
+    depends_on:
+      - clone_repos
+      - build_image_and_push_to_ecr
+
+  # Specific deploy to uat for EEC phase 4
+  - name: eec_phase_4_deploy_to_uat
+    pull: if-not-exists
+    image: quay.io/ukhomeofficedigital/kd:v1.14.0
+    environment:
+      KUBE_SERVER:
+        from_secret: kube_server_dev
+      KUBE_TOKEN:
+        from_secret: kube_token_dev
+    commands:
+      - sh bin/deploy.sh $${UAT_ENV}
+    when:
+      branch:
+        <<: *include_eec_phase_4_release_branch
       event: push
     depends_on:
       - clone_repos

--- a/.drone.yml
+++ b/.drone.yml
@@ -141,7 +141,7 @@ steps:
       - yarn run postinstall
     when:
       branch:
-        <<: *include_default_branch
+        <<: *include_default_and_feature_branches
       event: [push, pull_request]
     depends_on:
       - clone_repos


### PR DESCRIPTION
## What?

This PR adds an additional drone step to deploy to UAT when changes are merged into the new `eec-phase-4-release` branch.

## Why?

Because the EEC Phase 4 changes will take a number of sprints, to ensure current master remains in sync with live to support any potential live fixes, we have created a new `eec-phase-4-release` branch. This release branch will be used to combine all ongoing EEC Phase 4 changes so they can be UAT tested and completed on a sprint-by-sprint basis. To cater for this, we are adding a new drone workflow to deploy to UAT from this new release branch. 

## How?

Added an additional drone step and anchor to deploy to UAT on merge to the specified branch.


## Testing?

## Screenshots (optional)

## Anything Else? (optional)

## Check list

- [X] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
