### PR TITLE
EEC-164: Add new page for nationality.

### DIFF
--- a/apps/eec/behaviours/validate-autocomplete.js
+++ b/apps/eec/behaviours/validate-autocomplete.js
@@ -1,28 +1,31 @@
 const countries = require('hof').utils.countries();
 
 module.exports = selectField => superclass => class extends superclass {
-  validate(req, res, next) {
-    const autoFieldValue = req.body[`${selectField}-auto`] ?? undefined;
-
-    if (!selectField || autoFieldValue === undefined) {
-      return super.validate(req, res, next);
-    }
-
-    const autoFieldIsInvalid = !countries.some(country => country.value === autoFieldValue);
-
-    if (autoFieldIsInvalid) {
-      if (autoFieldValue === '') {
-        return next({[selectField]: new this.ValidationError(selectField, {
-          type: 'required',
-          redirect: undefined
-        })});
+  validateField(key, req) {
+    if (key === selectField) {
+      const autoFieldValue = req.body[`${selectField}-auto`] ?? undefined;
+      if (autoFieldValue === undefined) {
+        return super.validateField(key, req);
       }
 
-      return next({[selectField]: new this.ValidationError(selectField, {
-        type: 'invalidOption',
-        redirect: undefined
-      })});
+      const autoFieldIsInvalid = !countries.some(country => country.value === autoFieldValue);
+
+      if (autoFieldIsInvalid) {
+        // Order of this check is important to trigger invalidOption error when an invalid option is entered,
+        // and required error when the field is cleared
+        if (autoFieldValue !== '') {
+          return new this.ValidationError(key, {
+            type: 'invalidOption',
+            redirect: undefined
+          });
+        }
+
+        return new this.ValidationError(key, {
+          type: 'required',
+          redirect: undefined
+        });
+      }
     }
-    return super.validate(req, res, next);
+    return super.validateField(key, req);
   }
 };

--- a/apps/eec/fields/index.js
+++ b/apps/eec/fields/index.js
@@ -87,7 +87,6 @@ module.exports = {
   'travel-doc-nationality': {
     mixin: 'select',
     className: ['typeahead'],
-    validate: ['required'],
     options: [{
       value: '',
       label: 'fields.travel-doc-nationality.options.none_selected'
@@ -247,7 +246,6 @@ module.exports = {
   'correct-nationality': {
     mixin: 'select',
     className: ['typeahead'],
-    validate: ['required'],
     options: [{
       value: '',
       label: 'fields.correct-nationality.options.none_selected'
@@ -404,7 +402,6 @@ module.exports = {
   'requestor-nationality': {
     mixin: 'select',
     className: ['typeahead'],
-    validate: ['required'],
     options: [{
       value: '',
       label: 'fields.requestor-nationality.options.none_selected'

--- a/apps/eec/fields/index.js
+++ b/apps/eec/fields/index.js
@@ -171,9 +171,7 @@ module.exports = {
         value: 'problem-date-of-birth'
       },
       {
-        value: 'problem-nationality',
-        toggle: 'detail-nationality-toggle-content',
-        child: 'partials/detail-nationality'
+        value: 'problem-correct-nationality'
       },
       {
         value: 'problem-status',
@@ -246,19 +244,14 @@ module.exports = {
       { type: 'before', arguments: ['0', 'days'] }
     ]
   }),
-  'detail-nationality': {
+  'detail-correct-nationality': {
     mixin: 'select',
     className: ['typeahead'],
-    formGroupClassName: ['govuk-!-width-two-thirds'],
     validate: ['required'],
     options: [{
       value: '',
-      label: 'fields.detail-nationality.options.none_selected'
-    }].concat(countries),
-    validationLink: {
-      field: 'problem',
-      value: 'problem-nationality'
-    }
+      label: 'fields.detail-correct-nationality.options.none_selected'
+    }].concat(countries)
   },
   'detail-photo': {
     mixin: 'textarea',

--- a/apps/eec/fields/index.js
+++ b/apps/eec/fields/index.js
@@ -171,7 +171,7 @@ module.exports = {
         value: 'problem-date-of-birth'
       },
       {
-        value: 'problem-correct-nationality'
+        value: 'problem-nationality'
       },
       {
         value: 'problem-status',
@@ -244,13 +244,13 @@ module.exports = {
       { type: 'before', arguments: ['0', 'days'] }
     ]
   }),
-  'detail-correct-nationality': {
+  'correct-nationality': {
     mixin: 'select',
     className: ['typeahead'],
     validate: ['required'],
     options: [{
       value: '',
-      label: 'fields.detail-correct-nationality.options.none_selected'
+      label: 'fields.correct-nationality.options.none_selected'
     }].concat(countries)
   },
   'detail-photo': {

--- a/apps/eec/index.js
+++ b/apps/eec/index.js
@@ -123,7 +123,6 @@ module.exports = {
       next: '/personal-details',
       fields: [
         'problem',
-        'detail-nationality',
         'detail-status',
         'detail-valid-from',
         'detail-valid-until',
@@ -151,6 +150,13 @@ module.exports = {
           target: '/correct-date-of-birth',
           condition: req => req.sessionModel.get('problem') &&
           req.sessionModel.get('problem').includes('problem-date-of-birth')
+        },
+        {
+          target: '/correct-nationality',
+          condition: {
+            field: 'problem',
+            value: 'problem-correct-nationality'
+          }
         }
       ],
       showNeedHelp: true
@@ -166,6 +172,11 @@ module.exports = {
     '/correct-date-of-birth': {
       next: '/personal-details',
       fields: ['correct-date-of-birth'],
+      showNeedHelp: true
+    },
+    '/correct-nationality': {
+      next: '/personal-details',
+      fields: ['detail-correct-nationality'],
       showNeedHelp: true
     },
     '/personal-details': {

--- a/apps/eec/index.js
+++ b/apps/eec/index.js
@@ -153,10 +153,8 @@ module.exports = {
         },
         {
           target: '/correct-nationality',
-          condition: {
-            field: 'problem',
-            value: 'problem-correct-nationality'
-          }
+          condition: req => req.sessionModel.get('problem') &&
+          req.sessionModel.get('problem').includes('problem-nationality')
         }
       ],
       showNeedHelp: true
@@ -176,7 +174,7 @@ module.exports = {
     },
     '/correct-nationality': {
       next: '/personal-details',
-      fields: ['detail-correct-nationality'],
+      fields: ['correct-nationality'],
       showNeedHelp: true
     },
     '/personal-details': {

--- a/apps/eec/index.js
+++ b/apps/eec/index.js
@@ -47,7 +47,7 @@ module.exports = {
         'travel-doc-nationality',
         'travel-doc-dob'
       ],
-      behaviours: [validateAutocomplete('requestor-nationality')],
+      behaviours: [validateAutocomplete('travel-doc-nationality')],
       showNeedHelp: true
     },
     '/premium': {
@@ -175,6 +175,7 @@ module.exports = {
     '/correct-nationality': {
       next: '/personal-details',
       fields: ['correct-nationality'],
+      behaviours: [validateAutocomplete('correct-nationality')],
       showNeedHelp: true
     },
     '/personal-details': {

--- a/apps/eec/sections/summary-data-sections.js
+++ b/apps/eec/sections/summary-data-sections.js
@@ -48,8 +48,8 @@ module.exports = {
         parse: val => !val ? '' : formatDate(val)
       },
       {
-        step: '/problem',
-        field: 'detail-nationality'
+        step: '/correct-nationality',
+        field: 'detail-correct-nationality'
       },
       {
         step: '/problem',

--- a/apps/eec/sections/summary-data-sections.js
+++ b/apps/eec/sections/summary-data-sections.js
@@ -49,7 +49,7 @@ module.exports = {
       },
       {
         step: '/correct-nationality',
-        field: 'detail-correct-nationality'
+        field: 'correct-nationality'
       },
       {
         step: '/problem',

--- a/apps/eec/translations/src/en/fields.json
+++ b/apps/eec/translations/src/en/fields.json
@@ -93,7 +93,7 @@
       "problem-date-of-birth": {
         "label": "Date of birth"
       },
-      "problem-correct-nationality": {
+      "problem-nationality": {
         "label": "Nationality"
       },
       "problem-photo": {
@@ -141,7 +141,7 @@
     "legend": "Date of birth",
     "hint": "For example, 27 3 2007"
   },
-  "detail-correct-nationality": {
+  "correct-nationality": {
     "label": "Nationality",
     "options": {
       "none_selected": "Select a country"

--- a/apps/eec/translations/src/en/fields.json
+++ b/apps/eec/translations/src/en/fields.json
@@ -93,7 +93,7 @@
       "problem-date-of-birth": {
         "label": "Date of birth"
       },
-      "problem-nationality": {
+      "problem-correct-nationality": {
         "label": "Nationality"
       },
       "problem-photo": {
@@ -141,8 +141,8 @@
     "legend": "Date of birth",
     "hint": "For example, 27 3 2007"
   },
-  "detail-nationality": {
-    "label": "What is your correct nationality?",
+  "detail-correct-nationality": {
+    "label": "Nationality",
     "options": {
       "none_selected": "Select a country"
     }

--- a/apps/eec/translations/src/en/pages.json
+++ b/apps/eec/translations/src/en/pages.json
@@ -29,6 +29,10 @@
     "header": "What is your correct date of birth?",
     "intro": "You must enter the same details that you used in your visa application."
   },
+  "correct-nationality": {
+    "header": "What is your correct nationality?",
+    "intro": "You must enter the same details that you used in your visa application."
+  },
   "personal-details": {
     "header": "Personal details",
     "intro": "You must enter these details exactly as they appear on your eVisa so we can review the problem."
@@ -105,7 +109,7 @@
       "correct-date-of-birth": {
         "label": "Date of birth"
       },
-      "detail-nationality": {
+      "detail-correct-nationality": {
         "label": "Nationality"
       },
       "detail-photo": {

--- a/apps/eec/translations/src/en/pages.json
+++ b/apps/eec/translations/src/en/pages.json
@@ -109,7 +109,7 @@
       "correct-date-of-birth": {
         "label": "Date of birth"
       },
-      "detail-correct-nationality": {
+      "correct-nationality": {
         "label": "Nationality"
       },
       "detail-photo": {

--- a/apps/eec/translations/src/en/validation.json
+++ b/apps/eec/translations/src/en/validation.json
@@ -52,7 +52,7 @@
     "date": "Enter a real date",
     "before": "Your date of birth must be in the past"
   },
-  "detail-nationality": {
+  "detail-correct-nationality": {
     "required": "Enter your correct nationality"
   },
   "detail-photo": {

--- a/apps/eec/translations/src/en/validation.json
+++ b/apps/eec/translations/src/en/validation.json
@@ -52,7 +52,7 @@
     "date": "Enter a real date",
     "before": "Your date of birth must be in the past"
   },
-  "detail-correct-nationality": {
+  "correct-nationality": {
     "required": "Enter your correct nationality"
   },
   "detail-photo": {

--- a/apps/eec/translations/src/en/validation.json
+++ b/apps/eec/translations/src/en/validation.json
@@ -53,7 +53,8 @@
     "before": "Your date of birth must be in the past"
   },
   "correct-nationality": {
-    "required": "Enter your correct nationality"
+    "required": "Enter your nationality",
+    "invalidOption": "Enter your correct nationality"
   },
   "detail-photo": {
     "required": "Enter what is wrong with your photo",

--- a/apps/eec/views/partials/detail-nationality.html
+++ b/apps/eec/views/partials/detail-nationality.html
@@ -1,4 +1,0 @@
-
-<fieldset id="detail-nationality-toggle-content" class="govuk-radios__conditional" aria-hidden="false">
-    {{#renderField}}detail-nationality{{/renderField}}
-</fieldset>

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -5,13 +5,36 @@ require('hof/frontend/themes/gov-uk/client-js');
 
 const accessibleAutocomplete = require('accessible-autocomplete');
 
-document.querySelectorAll('.typeahead').forEach(function applyTypeahead(element) {
+function initTypeahead(element) {
+  const container = element.parentNode;
+
   accessibleAutocomplete.enhanceSelectElement({
     defaultValue: '',
     selectElement: element
   });
-});
 
-document.querySelectorAll('.autocomplete__input').forEach(function (element) {
-  element.setAttribute('name', element.id + '-auto');
-});
+  const input = container.querySelector('.autocomplete__input');
+  if (!input) {
+    return;
+  }
+
+  // This needed to do custom validation in validate-autocomplete behaviour
+  input.setAttribute('name', `${element.name}-auto`);
+  const values = Array.from(document.getElementById(`${element.name}-select`).options).map(option => option.value);
+
+  function clear() {
+    element.value = '';
+    element.dispatchEvent(new Event('change', { bubbles: true }));
+  }
+
+  input.addEventListener('input', () => {
+    // If user clears the field completely,
+    // clear the underlying select field and trigger validation error for required field
+    if (!input.value) clear();
+
+    // If user enters a value not in the values array, clear the field and trigger validation error
+    if (input.value && !values.includes(input.value)) clear();
+  });
+}
+
+document.querySelectorAll('.typeahead').forEach(initTypeahead);

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -28,11 +28,10 @@ function initTypeahead(element) {
   }
 
   input.addEventListener('input', () => {
-    // If user clears the field completely,
-    // clear the underlying select field and trigger validation error for required field
+    // If user clears the field completely
     if (!input.value) clear();
 
-    // If user enters a value not in the values array, clear the field and trigger validation error
+    // If user enters a value not in the values array
     if (input.value && !values.includes(input.value)) clear();
   });
 }

--- a/assets/scss/_autocomplete.scss
+++ b/assets/scss/_autocomplete.scss
@@ -133,6 +133,10 @@
   padding: 5px;
 }
 
+.govuk-form-group--error .autocomplete__input {
+  border: 2px solid #d4351c;
+}
+
 @media (min-width: 641px) {
   .autocomplete__hint,
   .autocomplete__input,

--- a/test/unit/validate-autocomplete.test.js
+++ b/test/unit/validate-autocomplete.test.js
@@ -8,20 +8,28 @@ describe('validate-autocomplete behaviour', () => {
   });
 
   let req;
-  let res;
   let instance;
   let validateAutocomplete;
 
   beforeEach(() => {
     req = reqres.req();
-    res = reqres.res();
+    req.form = {
+      options: {
+        fields: {
+          'test-field': {}
+        }
+      },
+      values: {
+        'test-field': 'France'
+      }
+    };
   });
 
   afterEach(() => {
     jest.restoreAllMocks();
   });
 
-  describe('The \'validate\' method', () => {
+  describe('The \'validateField\' method', () => {
     beforeEach(() => {
       validateAutocomplete = Behaviour('test-field')(Controller);
       instance = new validateAutocomplete({ template: 'index', route: '/index' });
@@ -33,41 +41,36 @@ describe('validate-autocomplete behaviour', () => {
 
     test('should throw a ValidationError if autocomplete fields contain invalid data', () => {
       req.body = { 'test-field-auto': 'bad-value' };
-      instance.validate(req, res, error => {
-        expect(error['test-field']).toBeInstanceOf(instance.ValidationError);
-        expect(error['test-field'].type).toBe('invalidOption');
-      });
+      const error = instance.validateField('test-field', req);
+      expect(error).toBeInstanceOf(instance.ValidationError);
+      expect(error.type).toBe('invalidOption');
     });
 
     test('should throw a ValidationError if autocomplete fields contain empty string data', () => {
       req.body = { 'test-field-auto': '' };
-      instance.validate(req, res, error => {
-        expect(error['test-field']).toBeInstanceOf(instance.ValidationError);
-        expect(error['test-field'].type).toBe('required');
-      });
+      const error = instance.validateField('test-field', req);
+      expect(error).toBeInstanceOf(instance.ValidationError);
+      expect(error.type).toBe('required');
     });
 
     test('should not throw an error if autocomplete fields contain valid data', () => {
       req.body = { 'test-field-auto': 'France' };
-      instance.validate(req, res, error => {
-        expect(error).toBeUndefined();
-      });
+      const error = instance.validateField('test-field', req);
+      expect(error).toBeNull();
     });
 
     test('should have returned early if the autocomplete input was not found in req.body', () => {
       req.body = {};
-      instance.validate(req, res, error => {
-        expect(error).toBeUndefined();
-      });
+      const error = instance.validateField('test-field', req);
+      expect(error).toBeNull();
     });
 
     test('should have returned early if no field was given to the behaviour in index.js', () => {
       validateAutocomplete = Behaviour()(Controller);
       instance = new validateAutocomplete({ template: 'index', route: '/index' });
       req.body = { 'test-field-auto': 'bad-value' };
-      instance.validate(req, res, error => {
-        expect(error).toBeUndefined();
-      });
+      const error = instance.validateField('test-field', req);
+      expect(error).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## What?
Added a new page to allow users to enter their correct nationality.
Previously, this was handled by toggling the input box behaviour on the problem page; I’ve now removed all of that legacy code.
Implemented conditional routing to navigate testers to the new page (this will be updated later as part of ticket EEC-149).


Fixed custom validation behaviour for the nationality/country dropdown across three pages(travel-doc-details, personal-details and correct-nationality). Two types of validation have been implemented:

Required validation – triggers when no value is provided
Invalid option validation – triggers when the user enters a value that does not exist in the dropdown list

Additionally, fixed a bug in the typeahead autocomplete behaviour. If a user clears the field completely or enters a value that is not present in the available options, the field is now cleared.

Current focus: the new page, validations, and the CYA page.


## Why?

[https://collaboration.homeoffice.gov.uk/jira/browse/EEC-164](https://collaboration.homeoffice.gov.uk/jira/browse/EEC-164)

## How?

## Testing?

## Screenshots (optional)

Page with required validation

<img width="599" height="621" alt="image" src="https://github.com/user-attachments/assets/c7748eae-ec89-4e32-95e4-14e0ca5f9a8b" />

Page with invalidOption validation

<img width="559" height="510" alt="image" src="https://github.com/user-attachments/assets/8bfbee81-edc3-4bf9-8ecc-618634b4dcb0" />

CYA page

<img width="553" height="73" alt="image" src="https://github.com/user-attachments/assets/59482ec3-7cdf-4db6-8763-7a71e20e01bb" />


## Anything Else? (optional)

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
