### PR TITLE
EEC-163: Add new page for Date Of Birth.

### DIFF
--- a/apps/eec/fields/index.js
+++ b/apps/eec/fields/index.js
@@ -168,9 +168,7 @@ module.exports = {
         value: 'problem-full-name'
       },
       {
-        value: 'problem-dob',
-        toggle: 'detail-dob-toggle-content',
-        child: 'partials/detail-dob'
+        value: 'problem-date-of-birth'
       },
       {
         value: 'problem-nationality',
@@ -240,17 +238,13 @@ module.exports = {
   'correct-last-name': {
     validate: ['required', validateText, { type: 'maxlength', arguments: 120 }]
   },
-  'detail-dob': dateComponent('detail-dob', {
+  'correct-date-of-birth': dateComponent('correct-date-of-birth', {
     mixin: 'input-date',
     validate: [
       'required',
       'date',
       { type: 'before', arguments: ['0', 'days'] }
-    ],
-    validationLink: {
-      field: 'problem',
-      value: 'problem-dob'
-    }
+    ]
   }),
   'detail-nationality': {
     mixin: 'select',

--- a/apps/eec/index.js
+++ b/apps/eec/index.js
@@ -160,7 +160,7 @@ module.exports = {
       fields: [
         'correct-given-names',
         'correct-last-name'
-      ],
+      ]
     },
     '/correct-date-of-birth': {
       next: '/personal-details',

--- a/apps/eec/index.js
+++ b/apps/eec/index.js
@@ -123,7 +123,6 @@ module.exports = {
       next: '/personal-details',
       fields: [
         'problem',
-        'detail-dob',
         'detail-nationality',
         'detail-status',
         'detail-valid-from',
@@ -147,6 +146,11 @@ module.exports = {
             }
             return false;
           }
+        },
+        {
+          target: '/correct-date-of-birth',
+          condition: req => req.sessionModel.get('problem') &&
+          req.sessionModel.get('problem').includes('problem-date-of-birth')
         }
       ],
       showNeedHelp: true
@@ -157,6 +161,10 @@ module.exports = {
         'correct-given-names',
         'correct-last-name'
       ],
+    },
+    '/correct-date-of-birth': {
+      next: '/personal-details',
+      fields: ['correct-date-of-birth'],
       showNeedHelp: true
     },
     '/personal-details': {

--- a/apps/eec/index.js
+++ b/apps/eec/index.js
@@ -160,7 +160,8 @@ module.exports = {
       fields: [
         'correct-given-names',
         'correct-last-name'
-      ]
+      ],
+      showNeedHelp: true
     },
     '/correct-date-of-birth': {
       next: '/personal-details',

--- a/apps/eec/sections/summary-data-sections.js
+++ b/apps/eec/sections/summary-data-sections.js
@@ -43,8 +43,8 @@ module.exports = {
         }
       },
       {
-        step: '/problem',
-        field: 'detail-dob',
+        step: '/correct-date-of-birth',
+        field: 'correct-date-of-birth',
         parse: val => !val ? '' : formatDate(val)
       },
       {

--- a/apps/eec/translations/src/en/fields.json
+++ b/apps/eec/translations/src/en/fields.json
@@ -90,7 +90,7 @@
       "problem-full-name": {
         "label": "Name"
       },
-      "problem-dob": {
+      "problem-date-of-birth": {
         "label": "Date of birth"
       },
       "problem-nationality": {
@@ -137,8 +137,8 @@
   "correct-last-name": {
     "label": "Last name"
   },
-  "detail-dob": {
-    "legend": "What is your correct date of birth?",
+  "correct-date-of-birth": {
+    "legend": "Date of birth",
     "hint": "For example, 27 3 2007"
   },
   "detail-nationality": {

--- a/apps/eec/translations/src/en/pages.json
+++ b/apps/eec/translations/src/en/pages.json
@@ -25,6 +25,10 @@
     "header": "What is your correct name?",
     "intro": "You must enter the same details that you used in your visa application."
   },
+  "correct-date-of-birth": {
+    "header": "What is your correct date of birth?",
+    "intro": "You must enter the same details that you used in your visa application."
+  },
   "personal-details": {
     "header": "Personal details",
     "intro": "You must enter these details exactly as they appear on your eVisa so we can review the problem."
@@ -98,7 +102,7 @@
       "correct-given-names": {
         "label": "Name"
       },
-      "detail-dob": {
+      "correct-date-of-birth": {
         "label": "Date of birth"
       },
       "detail-nationality": {

--- a/apps/eec/translations/src/en/validation.json
+++ b/apps/eec/translations/src/en/validation.json
@@ -47,10 +47,10 @@
     "validateText": "Last name must contain only letters a to z, spaces, hyphens and apostrophes",
     "maxlength": "Enter a last name that is 120 characters or less"
   },
-  "detail-dob": {
-    "required": "Enter your correct date of birth",
-    "date": "The date must only contain numbers. For example, 31 3 1980",
-    "before": "Date of birth must be in the past"
+  "correct-date-of-birth": {
+    "required": "Enter your date of birth",
+    "date": "Enter a real date",
+    "before": "Your date of birth must be in the past"
   },
   "detail-nationality": {
     "required": "Enter your correct nationality"

--- a/apps/eec/views/partials/detail-dob.html
+++ b/apps/eec/views/partials/detail-dob.html
@@ -1,4 +1,0 @@
-
-<fieldset id="detail-dob-toggle-content" class="govuk-radios__conditional" aria-hidden="false">
-    {{#renderField}}detail-dob{{/renderField}}
-</fieldset>


### PR DESCRIPTION
## What?
Added a new page to allow users to enter their correct date of birth.
Previously, this was handled by toggling the input box behaviour on the problem page; I’ve now removed all of that legacy code.
Implemented conditional routing to navigate testers to the new page (this will be updated later as part of ticket EEC-149).

Current focus: the new page, validations, and the CYA page.


## Why?
EEC-163
## How?

## Testing?

## Screenshots (optional)

Page with required validation

<img width="649" height="759" alt="image" src="https://github.com/user-attachments/assets/30f686d9-01b9-4ca4-819e-fdf46575524b" />

Page with one of invalid entry validation

<img width="632" height="507" alt="image" src="https://github.com/user-attachments/assets/a523e33d-07fa-4cc5-a982-9ec41c2aed6d" />

Page with future date validation

<img width="604" height="524" alt="image" src="https://github.com/user-attachments/assets/83bb8674-fda2-44d8-830c-6cbb45d94d1c" />

CYA page

<img width="649" height="65" alt="image" src="https://github.com/user-attachments/assets/c4dece2d-23dd-4015-a6a8-28d965071583" />


## Anything Else? (optional)

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
