### PR TITLE
EEC-165: Add immigration status problem page.

### DIFF
--- a/apps/eec/fields/index.js
+++ b/apps/eec/fields/index.js
@@ -250,6 +250,7 @@ module.exports = {
     }].concat(countries)
   },
   'problem-immigration-status': {
+    isPageHeading: 'true',
     validate: 'required'
   },
   'detail-photo': {

--- a/apps/eec/fields/index.js
+++ b/apps/eec/fields/index.js
@@ -173,9 +173,7 @@ module.exports = {
         value: 'problem-nationality'
       },
       {
-        value: 'problem-status',
-        toggle: 'detail-status',
-        child: 'input-text'
+        value: 'problem-status'
       },
       {
         value: 'problem-valid-from',
@@ -251,6 +249,9 @@ module.exports = {
       label: 'fields.correct-nationality.options.none_selected'
     }].concat(countries)
   },
+  'problem-immigration-status': {
+    validate: 'required'
+  },
   'detail-photo': {
     mixin: 'textarea',
     validate: ['required', { type: 'maxlength', arguments: 500 }],
@@ -285,14 +286,6 @@ module.exports = {
     dependent: {
       field: 'problem',
       value: 'problem-share-code'
-    }
-  },
-  'detail-status': {
-    mixin: 'input-text',
-    validate: 'required',
-    dependent: {
-      field: 'problem',
-      value: 'problem-status'
     }
   },
   'detail-valid-from': {

--- a/apps/eec/index.js
+++ b/apps/eec/index.js
@@ -123,7 +123,6 @@ module.exports = {
       next: '/personal-details',
       fields: [
         'problem',
-        'detail-status',
         'detail-valid-from',
         'detail-valid-until',
         'detail-nin',
@@ -155,6 +154,11 @@ module.exports = {
           target: '/correct-nationality',
           condition: req => req.sessionModel.get('problem') &&
           req.sessionModel.get('problem').includes('problem-nationality')
+        },
+        {
+          target: '/problem-immigration-status',
+          condition: req => req.sessionModel.get('problem') &&
+          req.sessionModel.get('problem').includes('problem-status')
         }
       ],
       showNeedHelp: true
@@ -176,6 +180,11 @@ module.exports = {
       next: '/personal-details',
       fields: ['correct-nationality'],
       behaviours: [validateAutocomplete('correct-nationality')],
+      showNeedHelp: true
+    },
+    '/problem-immigration-status': {
+      next: '/personal-details',
+      fields: ['problem-immigration-status'],
       showNeedHelp: true
     },
     '/personal-details': {

--- a/apps/eec/sections/summary-data-sections.js
+++ b/apps/eec/sections/summary-data-sections.js
@@ -52,8 +52,8 @@ module.exports = {
         field: 'correct-nationality'
       },
       {
-        step: '/problem',
-        field: 'detail-status'
+        step: '/problem-immigration-status',
+        field: 'problem-immigration-status'
       },
       {
         step: '/problem',

--- a/apps/eec/translations/src/en/fields.json
+++ b/apps/eec/translations/src/en/fields.json
@@ -148,7 +148,7 @@
     }
   },
   "problem-immigration-status": {
-    "label": " ",
+    "label": "What problem are you having with your immigration status?",
     "hint": "This could be because your status is old, incorrect or you cannot view it"
   },
   "detail-photo": {

--- a/apps/eec/translations/src/en/fields.json
+++ b/apps/eec/translations/src/en/fields.json
@@ -147,6 +147,10 @@
       "none_selected": "Select a country"
     }
   },
+  "problem-immigration-status": {
+    "label": " ",
+    "hint": "This could be because your status is old, incorrect or you cannot view it"
+  },
   "detail-photo": {
     "label": "What is wrong with your photo?"
   },
@@ -159,10 +163,6 @@
   "detail-share-code": {
     "label": "Which share code are you unable to create?",
     "hint": "This could be for right to work, right to rent or something else"
-  },
-  "detail-status": {
-    "label": "What problem are you having with your immigration status?",
-    "hint": "This could be because your status is old, incorrect or you cannot view it"
   },
   "detail-valid-from": {
     "label": "What is the correct date your visa is valid from?"

--- a/apps/eec/translations/src/en/pages.json
+++ b/apps/eec/translations/src/en/pages.json
@@ -33,9 +33,6 @@
     "header": "What is your correct nationality?",
     "intro": "You must enter the same details that you used in your visa application."
   },
-  "problem-immigration-status": {
-    "header": "What problem are you having with your immigration status?"
-  },
   "personal-details": {
     "header": "Personal details",
     "intro": "You must enter these details exactly as they appear on your eVisa so we can review the problem."

--- a/apps/eec/translations/src/en/pages.json
+++ b/apps/eec/translations/src/en/pages.json
@@ -33,6 +33,9 @@
     "header": "What is your correct nationality?",
     "intro": "You must enter the same details that you used in your visa application."
   },
+  "problem-immigration-status": {
+    "header": "What problem are you having with your immigration status?"
+  },
   "personal-details": {
     "header": "Personal details",
     "intro": "You must enter these details exactly as they appear on your eVisa so we can review the problem."
@@ -112,6 +115,9 @@
       "correct-nationality": {
         "label": "Nationality"
       },
+      "problem-immigration-status": {
+        "label": "Status"
+      },
       "detail-photo": {
         "label": "Photo"
       },
@@ -123,9 +129,6 @@
       },
       "detail-share-code": {
         "label": "Share code"
-      },
-      "detail-status": {
-        "label": "Status"
       },
       "detail-valid-from": {
         "label": "Valid from"

--- a/apps/eec/translations/src/en/validation.json
+++ b/apps/eec/translations/src/en/validation.json
@@ -56,6 +56,9 @@
     "required": "Enter your nationality",
     "invalidOption": "Enter your correct nationality"
   },
+  "problem-immigration-status": {
+    "required": "Enter what is wrong with your status"
+  },
   "detail-photo": {
     "required": "Enter what is wrong with your photo",
     "maxlength": "You have exceeded the 500 character limit"
@@ -69,9 +72,6 @@
   },
   "detail-share-code": {
     "required": "Enter which share code you are unable to create"
-  },
-  "detail-status": {
-    "required": "Enter what is wrong with your status"
   },
   "detail-valid-from": {
     "required": "Enter the correct valid from date"


### PR DESCRIPTION
## What?
Added a new page enabling users to provide details of problems they are experiencing with their immigration status.
Previously, this was handled by toggling the input box behaviour on the problem page; all of that legacy code has now been removed.
Implemented conditional routing to navigate testers to the new page (this will be updated later as part of ticket EEC-149).

Current focus: the new page, validations, and the CYA page.

## Why?
[https://collaboration.homeoffice.gov.uk/jira/browse/EEC-165](https://collaboration.homeoffice.gov.uk/jira/browse/EEC-165)
## How?

## Testing?

## Screenshots (optional)

With required validation

<img width="716" height="782" alt="image" src="https://github.com/user-attachments/assets/f300b681-daae-4930-a880-e9d5c7d57994" />

CYA page

<img width="685" height="78" alt="image" src="https://github.com/user-attachments/assets/2367208d-c6d9-4c05-8b5b-29bb5dd83be0" />


## Anything Else? (optional)

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
