### PR TITLE
EEC-172: Add new page for sponsor license number.

### DIFF
--- a/apps/eec/fields/index.js
+++ b/apps/eec/fields/index.js
@@ -261,7 +261,8 @@ module.exports = {
     ]
   },
   'correct-sponsor-licence-number': {
-    validate: 'required'
+    validate: 'required',
+    formatter: ['removespaces']
   },
   'detail-photo': {
     mixin: 'textarea',

--- a/apps/eec/fields/index.js
+++ b/apps/eec/fields/index.js
@@ -190,6 +190,9 @@ module.exports = {
         value: 'problem-national-insurance-number'
       },
       {
+        value: 'problem-sponsor-licence-number'
+      },
+      {
         value: 'problem-photo',
         toggle: 'detail-photo',
         child: 'textarea'
@@ -212,11 +215,6 @@ module.exports = {
       {
         value: 'problem-signin-phone',
         toggle: 'detail-signin-phone',
-        child: 'input-text'
-      },
-      {
-        value: 'problem-sponsor-licence-number',
-        toggle: 'detail-sponsor-licence-number',
         child: 'input-text'
       },
       {
@@ -261,6 +259,9 @@ module.exports = {
       'required',
       NIValidator
     ]
+  },
+  'correct-sponsor-licence-number': {
+    validate: 'required'
   },
   'detail-photo': {
     mixin: 'textarea',
@@ -336,16 +337,6 @@ module.exports = {
     dependent: {
       field: 'problem',
       value: 'problem-other'
-    }
-  },
-  'detail-sponsor-licence-number': {
-    mixin: 'input-text',
-    validate: ['required', { type: 'maxlength', arguments: 20 }, 'alphanum'],
-    formatter: ['removespaces'],
-    className: ['govuk-input', 'govuk-!-width-one-third'],
-    dependent: {
-      field: 'problem',
-      value: 'problem-sponsor-licence-number'
     }
   },
   'is-refugee': {

--- a/apps/eec/index.js
+++ b/apps/eec/index.js
@@ -130,7 +130,6 @@ module.exports = {
         'detail-share-code',
         'detail-signin-email',
         'detail-signin-phone',
-        'detail-sponsor-licence-number',
         'detail-other'
       ],
       forks: [
@@ -163,6 +162,11 @@ module.exports = {
           target: '/national-insurance-number',
           condition: req => req.sessionModel.get('problem') &&
           req.sessionModel.get('problem').includes('problem-national-insurance-number')
+        },
+        {
+          target: '/sponsor-licence-number',
+          condition: req => req.sessionModel.get('problem') &&
+          req.sessionModel.get('problem').includes('problem-sponsor-licence-number')
         }
       ],
       showNeedHelp: true
@@ -194,6 +198,11 @@ module.exports = {
     '/national-insurance-number': {
       next: '/personal-details',
       fields: ['correct-national-insurance-number'],
+      showNeedHelp: true
+    },
+    '/sponsor-licence-number': {
+      next: '/personal-details',
+      fields: ['correct-sponsor-licence-number'],
       showNeedHelp: true
     },
     '/personal-details': {

--- a/apps/eec/sections/summary-data-sections.js
+++ b/apps/eec/sections/summary-data-sections.js
@@ -68,6 +68,10 @@ module.exports = {
         field: 'correct-national-insurance-number'
       },
       {
+        step: '/sponsor-licence-number',
+        field: 'correct-sponsor-licence-number'
+      },
+      {
         step: '/problem',
         field: 'detail-photo'
       },
@@ -86,10 +90,6 @@ module.exports = {
       {
         step: '/problem',
         field: 'detail-signin-phone'
-      },
-      {
-        step: '/problem',
-        field: 'detail-sponsor-licence-number'
       },
       {
         step: '/problem',

--- a/apps/eec/translations/src/en/fields.json
+++ b/apps/eec/translations/src/en/fields.json
@@ -158,6 +158,9 @@
     "label": "National Insurance number",
     "hint": "It's on your National Insurance card, benefit letter, payslip or P60 - for example, 'QQ 12 34 56 C'"
   },
+  "correct-sponsor-licence-number": {
+    "label": "Sponsor licence number"
+  },
   "detail-restrictions": {
     "label": "What is wrong with the details of what you can and cannot do in the UK?"
   },
@@ -179,9 +182,6 @@
   },
   "detail-other": {
     "label": "Describe the problem you are having"
-  },
-  "detail-sponsor-licence-number": {
-    "label": "What is your correct sponsor licence number?"
   },
   "is-refugee": {
     "legend": "Do you have permission to stay in the UK as a refugee?",

--- a/apps/eec/translations/src/en/pages.json
+++ b/apps/eec/translations/src/en/pages.json
@@ -37,6 +37,10 @@
     "header": "What is your correct National Insurance number?",
     "intro": "You must enter the same details that you used in your visa application."
   },
+  "sponsor-licence-number": {
+    "header": "What is your correct sponsor licence number?",
+    "intro": "You must enter the same details that you used in your visa application."
+  },
   "personal-details": {
     "header": "Personal details",
     "intro": "You must enter these details exactly as they appear on your eVisa so we can review the problem."
@@ -125,6 +129,9 @@
       "correct-national-insurance-number": {
         "label": "National Insurance number"
       },
+      "correct-sponsor-licence-number": {
+        "label": "Sponsor licence number"
+      },
       "detail-restrictions": {
         "label": "What you can and cannot do in the UK"
       },
@@ -145,9 +152,6 @@
       },
       "detail-other": {
         "label": "My problem isn't listed"
-      },
-      "detail-sponsor-licence-number": {
-        "label": "Sponsor licence number"
       },
       "requestor-full-name": {
         "label": "Full name"

--- a/apps/eec/translations/src/en/validation.json
+++ b/apps/eec/translations/src/en/validation.json
@@ -67,6 +67,9 @@
     "required": "Enter your National Insurance number",
     "regex" : "Enter a National Insurance number in the correct format"
   },
+  "correct-sponsor-licence-number": {
+    "required": "Enter your sponsor licence number"
+  },
   "detail-restrictions": {
     "required": "Enter what is wrong with the details of what you can and cannot do in the UK",
     "maxlength": "You have exceeded the 500 character limit"
@@ -89,11 +92,6 @@
     "required": "Enter the correct phone number where you can receive security codes",
     "internationalPhoneNumber": "Enter a phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192",
     "regex": "Enter a phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192"
-  },
-  "detail-sponsor-licence-number": {
-    "required": "Enter your correct sponsor licence number",
-    "maxlength": "Sponsor licence number must be 20 characters or less",
-    "alphanum": "Sponsor licence number must only include letters a to z and numbers"
   },
   "detail-other": {
     "required": "Enter the problem that isn't listed",


### PR DESCRIPTION
## What?
Added a new page enabling users to enter their correct sponsor license number.
Previously, this was handled by toggling the input box behaviour on the problem page; all of that legacy code has now been removed.
Implemented conditional routing to navigate testers to the new page (this will be updated later as part of ticket EEC-149).

Current focus: the new page, validations, and the CYA page.

## Why?
[https://collaboration.homeoffice.gov.uk/jira/browse/EEC-172](https://collaboration.homeoffice.gov.uk/jira/browse/EEC-172)

## How?

## Testing?

## Screenshots (optional)

With required validation

<img width="731" height="800" alt="image" src="https://github.com/user-attachments/assets/4e09ccd2-9c47-49cf-a4a2-43cd7acfc108" />

CYA page

<img width="682" height="97" alt="image" src="https://github.com/user-attachments/assets/67ec9a79-c7a0-45b4-a4c4-2c2c1e841db5" />


## Anything Else? (optional)

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
