### PR TITLE
EEC-173: Add new page to enter problems with photo.

### DIFF
--- a/apps/eec/fields/index.js
+++ b/apps/eec/fields/index.js
@@ -193,9 +193,7 @@ module.exports = {
         value: 'problem-sponsor-licence-number'
       },
       {
-        value: 'problem-photo',
-        toggle: 'detail-photo',
-        child: 'textarea'
+        value: 'problem-photo'
       },
       {
         value: 'problem-restrictions',
@@ -264,14 +262,10 @@ module.exports = {
     validate: 'required',
     formatter: ['removespaces']
   },
-  'detail-photo': {
+  photo: {
     mixin: 'textarea',
-    validate: ['required', { type: 'maxlength', arguments: 500 }],
-    attributes: [{ attribute: 'rows', value: 5 }],
-    dependent: {
-      field: 'problem',
-      value: 'problem-photo'
-    }
+    validate: ['required'],
+    attributes: [{ attribute: 'rows', value: 5 }]
   },
   'detail-restrictions': {
     mixin: 'textarea',

--- a/apps/eec/index.js
+++ b/apps/eec/index.js
@@ -125,7 +125,6 @@ module.exports = {
         'problem',
         'detail-valid-from',
         'detail-valid-until',
-        'detail-photo',
         'detail-restrictions',
         'detail-share-code',
         'detail-signin-email',
@@ -167,6 +166,11 @@ module.exports = {
           target: '/sponsor-licence-number',
           condition: req => req.sessionModel.get('problem') &&
           req.sessionModel.get('problem').includes('problem-sponsor-licence-number')
+        },
+        {
+          target: '/photo',
+          condition: req => req.sessionModel.get('problem') &&
+          req.sessionModel.get('problem').includes('problem-photo')
         }
       ],
       showNeedHelp: true
@@ -203,6 +207,11 @@ module.exports = {
     '/sponsor-licence-number': {
       next: '/personal-details',
       fields: ['correct-sponsor-licence-number'],
+      showNeedHelp: true
+    },
+    '/photo': {
+      next: '/personal-details',
+      fields: ['photo'],
       showNeedHelp: true
     },
     '/personal-details': {

--- a/apps/eec/sections/summary-data-sections.js
+++ b/apps/eec/sections/summary-data-sections.js
@@ -72,8 +72,8 @@ module.exports = {
         field: 'correct-sponsor-licence-number'
       },
       {
-        step: '/problem',
-        field: 'detail-photo'
+        step: '/photo',
+        field: 'photo'
       },
       {
         step: '/problem',

--- a/apps/eec/translations/src/en/fields.json
+++ b/apps/eec/translations/src/en/fields.json
@@ -96,11 +96,11 @@
       "problem-nationality": {
         "label": "Nationality"
       },
-      "problem-photo": {
-        "label": "Photo"
-      },
       "problem-national-insurance-number": {
         "label": "National Insurance number"
+      },
+      "problem-photo": {
+        "label": "Photo"
       },
       "problem-restrictions": {
         "label": "What you can and cannot do in the UK"
@@ -151,15 +151,15 @@
     "label": "What problem are you having with your immigration status?",
     "hint": "This could be because your status is old, incorrect or you cannot view it"
   },
-  "detail-photo": {
-    "label": "What is wrong with your photo?"
-  },
   "correct-national-insurance-number": {
     "label": "National Insurance number",
     "hint": "It's on your National Insurance card, benefit letter, payslip or P60 - for example, 'QQ 12 34 56 C'"
   },
   "correct-sponsor-licence-number": {
     "label": "Sponsor licence number"
+  },
+  "photo": {
+    "label": "Describe the problem you are having with your photo"
   },
   "detail-restrictions": {
     "label": "What is wrong with the details of what you can and cannot do in the UK?"

--- a/apps/eec/translations/src/en/pages.json
+++ b/apps/eec/translations/src/en/pages.json
@@ -41,6 +41,9 @@
     "header": "What is your correct sponsor licence number?",
     "intro": "You must enter the same details that you used in your visa application."
   },
+  "photo": {
+    "header": "What is wrong with your photo?"
+  },
   "personal-details": {
     "header": "Personal details",
     "intro": "You must enter these details exactly as they appear on your eVisa so we can review the problem."
@@ -123,14 +126,14 @@
       "problem-immigration-status": {
         "label": "Status"
       },
-      "detail-photo": {
-        "label": "Photo"
-      },
       "correct-national-insurance-number": {
         "label": "National Insurance number"
       },
       "correct-sponsor-licence-number": {
         "label": "Sponsor licence number"
+      },
+      "photo": {
+        "label": "Photo"
       },
       "detail-restrictions": {
         "label": "What you can and cannot do in the UK"

--- a/apps/eec/translations/src/en/validation.json
+++ b/apps/eec/translations/src/en/validation.json
@@ -59,16 +59,15 @@
   "problem-immigration-status": {
     "required": "Enter what is wrong with your status"
   },
-  "detail-photo": {
-    "required": "Enter what is wrong with your photo",
-    "maxlength": "You have exceeded the 500 character limit"
-  },
   "correct-national-insurance-number": {
     "required": "Enter your National Insurance number",
     "regex" : "Enter a National Insurance number in the correct format"
   },
   "correct-sponsor-licence-number": {
     "required": "Enter your sponsor licence number"
+  },
+  "photo": {
+    "required": "Describe the problem you are having"
   },
   "detail-restrictions": {
     "required": "Enter what is wrong with the details of what you can and cannot do in the UK",


### PR DESCRIPTION
## What?
Added a new page enabling users to provide details of problems they are experiencing with their photo.
Previously, this was handled by toggling the input box behaviour on the problem page; all of that legacy code has now been removed.
Implemented conditional routing to navigate testers to the new page (this will be updated later as part of ticket EEC-149).

Current focus: the new page, validations, and the CYA page.
## Why?

[https://collaboration.homeoffice.gov.uk/jira/browse/EEC-173](https://collaboration.homeoffice.gov.uk/jira/browse/EEC-173)

## How?

## Testing?

## Screenshots (optional)

with required validation

<img width="746" height="811" alt="image" src="https://github.com/user-attachments/assets/9eaf842a-3225-4b6c-a4e5-475c1c074e93" />

CYA page

<img width="706" height="70" alt="image" src="https://github.com/user-attachments/assets/d8ba843c-d56a-42e1-a122-d86161b5cd41" />


## Anything Else? (optional)

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
