### PR TITLE
EEC-174: Add new page to enter correct name of future partner.

### DIFF
--- a/apps/eec/fields/index.js
+++ b/apps/eec/fields/index.js
@@ -270,10 +270,10 @@ module.exports = {
     validate: ['required'],
     attributes: [{ attribute: 'rows', value: 5 }]
   },
-  'correct-future-partner-given-names': {
+  'future-partner-correct-given-names': {
     validate: ['required', validateText, { type: 'maxlength', arguments: 120 }]
   },
-  'correct-future-partner-last-name': {
+  'future-partner-correct-last-name': {
     validate: ['required', validateText, { type: 'maxlength', arguments: 120 }]
   },
   'detail-restrictions': {

--- a/apps/eec/fields/index.js
+++ b/apps/eec/fields/index.js
@@ -196,6 +196,9 @@ module.exports = {
         value: 'problem-photo'
       },
       {
+        value: 'problem-future-partner-name'
+      },
+      {
         value: 'problem-restrictions',
         toggle: 'detail-restrictions',
         child: 'textarea'
@@ -266,6 +269,12 @@ module.exports = {
     mixin: 'textarea',
     validate: ['required'],
     attributes: [{ attribute: 'rows', value: 5 }]
+  },
+  'correct-future-partner-given-names': {
+    validate: ['required', validateText, { type: 'maxlength', arguments: 120 }]
+  },
+  'correct-future-partner-last-name': {
+    validate: ['required', validateText, { type: 'maxlength', arguments: 120 }]
   },
   'detail-restrictions': {
     mixin: 'textarea',

--- a/apps/eec/index.js
+++ b/apps/eec/index.js
@@ -171,6 +171,11 @@ module.exports = {
           target: '/photo',
           condition: req => req.sessionModel.get('problem') &&
           req.sessionModel.get('problem').includes('problem-photo')
+        },
+        {
+          target: '/future-partner-name',
+          condition: req => req.sessionModel.get('problem') &&
+          req.sessionModel.get('problem').includes('problem-future-partner-name')
         }
       ],
       showNeedHelp: true
@@ -212,6 +217,14 @@ module.exports = {
     '/photo': {
       next: '/personal-details',
       fields: ['photo'],
+      showNeedHelp: true
+    },
+    '/future-partner-name': {
+      next: '/personal-details',
+      fields: [
+        'correct-future-partner-given-names',
+        'correct-future-partner-last-name'
+      ],
       showNeedHelp: true
     },
     '/personal-details': {

--- a/apps/eec/index.js
+++ b/apps/eec/index.js
@@ -222,8 +222,8 @@ module.exports = {
     '/future-partner-name': {
       next: '/personal-details',
       fields: [
-        'correct-future-partner-given-names',
-        'correct-future-partner-last-name'
+        'future-partner-correct-given-names',
+        'future-partner-correct-last-name'
       ],
       showNeedHelp: true
     },

--- a/apps/eec/sections/summary-data-sections.js
+++ b/apps/eec/sections/summary-data-sections.js
@@ -77,13 +77,13 @@ module.exports = {
       },
       {
         step: '/future-partner-name',
-        field: 'correct-future-partner-given-names',
+        field: 'future-partner-correct-given-names',
         parse: (val, req) => {
           if (!req.sessionModel.get('steps').includes('/future-partner-name')) {
             return null;
           }
-          const givenNames = req.sessionModel.get('correct-future-partner-given-names');
-          const lastName = req.sessionModel.get('correct-future-partner-last-name');
+          const givenNames = req.sessionModel.get('future-partner-correct-given-names');
+          const lastName = req.sessionModel.get('future-partner-correct-last-name');
           return `${givenNames} ${lastName}`;
         }
       },

--- a/apps/eec/sections/summary-data-sections.js
+++ b/apps/eec/sections/summary-data-sections.js
@@ -76,6 +76,18 @@ module.exports = {
         field: 'photo'
       },
       {
+        step: '/future-partner-name',
+        field: 'correct-future-partner-given-names',
+        parse: (val, req) => {
+          if (!req.sessionModel.get('steps').includes('/future-partner-name')) {
+            return null;
+          }
+          const givenNames = req.sessionModel.get('correct-future-partner-given-names');
+          const lastName = req.sessionModel.get('correct-future-partner-last-name');
+          return `${givenNames} ${lastName}`;
+        }
+      },
+      {
         step: '/problem',
         field: 'detail-restrictions'
       },

--- a/apps/eec/translations/src/en/fields.json
+++ b/apps/eec/translations/src/en/fields.json
@@ -164,10 +164,10 @@
   "photo": {
     "label": "Describe the problem you are having with your photo"
   },
-  "correct-future-partner-given-names": {
+  "future-partner-correct-given-names": {
     "label": "Given names"
   },
-  "correct-future-partner-last-name": {
+  "future-partner-correct-last-name": {
     "label": "Last name"
   },
   "detail-restrictions": {

--- a/apps/eec/translations/src/en/fields.json
+++ b/apps/eec/translations/src/en/fields.json
@@ -102,6 +102,9 @@
       "problem-photo": {
         "label": "Photo"
       },
+      "problem-future-partner-name": {
+        "label": "Future spouse or civil partner name"
+      },
       "problem-restrictions": {
         "label": "What you can and cannot do in the UK"
       },
@@ -160,6 +163,12 @@
   },
   "photo": {
     "label": "Describe the problem you are having with your photo"
+  },
+  "correct-future-partner-given-names": {
+    "label": "Given names"
+  },
+  "correct-future-partner-last-name": {
+    "label": "Last name"
   },
   "detail-restrictions": {
     "label": "What is wrong with the details of what you can and cannot do in the UK?"

--- a/apps/eec/translations/src/en/pages.json
+++ b/apps/eec/translations/src/en/pages.json
@@ -44,6 +44,10 @@
   "photo": {
     "header": "What is wrong with your photo?"
   },
+  "future-partner-name": {
+    "header": "What is the correct name of your future partner?",
+    "intro": "You must enter the same details that you used in your visa application."
+  },
   "personal-details": {
     "header": "Personal details",
     "intro": "You must enter these details exactly as they appear on your eVisa so we can review the problem."
@@ -134,6 +138,9 @@
       },
       "photo": {
         "label": "Photo"
+      },
+      "correct-future-partner-given-names": {
+        "label": "Future spouse or civil partner name"
       },
       "detail-restrictions": {
         "label": "What you can and cannot do in the UK"

--- a/apps/eec/translations/src/en/pages.json
+++ b/apps/eec/translations/src/en/pages.json
@@ -139,7 +139,7 @@
       "photo": {
         "label": "Photo"
       },
-      "correct-future-partner-given-names": {
+      "future-partner-correct-given-names": {
         "label": "Future spouse or civil partner name"
       },
       "detail-restrictions": {

--- a/apps/eec/translations/src/en/validation.json
+++ b/apps/eec/translations/src/en/validation.json
@@ -69,6 +69,16 @@
   "photo": {
     "required": "Describe the problem you are having"
   },
+  "correct-future-partner-given-names": {
+    "required": "Enter their given names",
+    "validateText": "Given names must contain only letters a to z, spaces, hyphens and apostrophes",
+    "maxlength": "Enter given names that are 120 characters or less"
+  },
+  "correct-future-partner-last-name": {
+    "required": "Enter their last name",
+    "validateText": "Last name must contain only letters a to z, spaces, hyphens and apostrophes",
+    "maxlength": "Enter a last name that is 120 characters or less"
+  },
   "detail-restrictions": {
     "required": "Enter what is wrong with the details of what you can and cannot do in the UK",
     "maxlength": "You have exceeded the 500 character limit"

--- a/apps/eec/translations/src/en/validation.json
+++ b/apps/eec/translations/src/en/validation.json
@@ -69,12 +69,12 @@
   "photo": {
     "required": "Describe the problem you are having"
   },
-  "correct-future-partner-given-names": {
+  "future-partner-correct-given-names": {
     "required": "Enter their given names",
     "validateText": "Given names must contain only letters a to z, spaces, hyphens and apostrophes",
     "maxlength": "Enter given names that are 120 characters or less"
   },
-  "correct-future-partner-last-name": {
+  "future-partner-correct-last-name": {
     "required": "Enter their last name",
     "validateText": "Last name must contain only letters a to z, spaces, hyphens and apostrophes",
     "maxlength": "Enter a last name that is 120 characters or less"


### PR DESCRIPTION
## What?
Added a new page enabling users to provide correct name of their future partner.
This is completely a new option for problem checklist page too, so added a new checkbox in problem page.

Implemented conditional routing to navigate testers to the new page (this will be updated later as part of ticket EEC-149).

CYA page shows after concatenated both Given names and Last name and displayed as Future spouse or civil partner name, which is checkbox field label from the problem page. 

Current focus: the new page, validations, and the CYA page.

## Why?

EEC-174

## How?

## Testing?

## Screenshots (optional)

With required validation

<img width="617" height="774" alt="image" src="https://github.com/user-attachments/assets/f0d13bcf-5d97-4e31-8182-66d0ff53e11b" />

With invalid validation

<img width="566" height="747" alt="image" src="https://github.com/user-attachments/assets/7087765c-2537-414c-8169-1caeb06c928a" />

With max length validation

<img width="600" height="572" alt="image" src="https://github.com/user-attachments/assets/4e83735e-66fe-4b64-893b-e8752972beb9" />


CYA page

<img width="584" height="86" alt="image" src="https://github.com/user-attachments/assets/b74cc0d4-0346-4641-aa47-d77376cdc213" />

## Anything Else? (optional)

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
