### PR TITLE
EEC-175: Add new page to choose number of adults accompany a child.

### DIFF
--- a/apps/eec/fields/index.js
+++ b/apps/eec/fields/index.js
@@ -199,6 +199,9 @@ module.exports = {
         value: 'problem-future-partner-name'
       },
       {
+        value: 'problem-accompanying-adult-details'
+      },
+      {
         value: 'problem-restrictions',
         toggle: 'detail-restrictions',
         child: 'textarea'
@@ -275,6 +278,23 @@ module.exports = {
   },
   'future-partner-correct-last-name': {
     validate: ['required', validateText, { type: 'maxlength', arguments: 120 }]
+  },
+  'how-many-adults': {
+    isPageHeading: 'true',
+    mixin: 'radio-group',
+    className: ['govuk-radios'],
+    validate: 'required',
+    options: [
+      {
+        value: '1-adult'
+      },
+      {
+        value: '2-adults'
+      }
+    ],
+    legend: {
+      className: 'govuk-!-margin-bottom-6'
+    }
   },
   'detail-restrictions': {
     mixin: 'textarea',

--- a/apps/eec/index.js
+++ b/apps/eec/index.js
@@ -176,6 +176,11 @@ module.exports = {
           target: '/future-partner-name',
           condition: req => req.sessionModel.get('problem') &&
           req.sessionModel.get('problem').includes('problem-future-partner-name')
+        },
+        {
+          target: '/how-many-adults',
+          condition: req => req.sessionModel.get('problem') &&
+          req.sessionModel.get('problem').includes('problem-accompanying-adult-details')
         }
       ],
       showNeedHelp: true
@@ -225,6 +230,11 @@ module.exports = {
         'future-partner-correct-given-names',
         'future-partner-correct-last-name'
       ],
+      showNeedHelp: true
+    },
+    '/how-many-adults': {
+      next: '/personal-details',
+      fields: ['how-many-adults'],
       showNeedHelp: true
     },
     '/personal-details': {

--- a/apps/eec/sections/summary-data-sections.js
+++ b/apps/eec/sections/summary-data-sections.js
@@ -88,6 +88,10 @@ module.exports = {
         }
       },
       {
+        step: '/how-many-adults',
+        field: 'how-many-adults'
+      },
+      {
         step: '/problem',
         field: 'detail-restrictions'
       },

--- a/apps/eec/translations/src/en/fields.json
+++ b/apps/eec/translations/src/en/fields.json
@@ -105,6 +105,9 @@
       "problem-future-partner-name": {
         "label": "Future spouse or civil partner name"
       },
+      "problem-accompanying-adult-details": {
+        "label": "Name or passport numbers of accompanying adult"
+      },
       "problem-restrictions": {
         "label": "What you can and cannot do in the UK"
       },
@@ -169,6 +172,17 @@
   },
   "future-partner-correct-last-name": {
     "label": "Last name"
+  },
+  "how-many-adults": {
+    "legend": "How many adults have been approved to accompany a child?",
+    "options": {
+      "1-adult": {
+        "label": "1 adult"
+      },
+      "2-adults": {
+        "label": "2 adults"
+      }
+    }
   },
   "detail-restrictions": {
     "label": "What is wrong with the details of what you can and cannot do in the UK?"

--- a/apps/eec/translations/src/en/pages.json
+++ b/apps/eec/translations/src/en/pages.json
@@ -142,6 +142,9 @@
       "future-partner-correct-given-names": {
         "label": "Future spouse or civil partner name"
       },
+      "how-many-adults": {
+        "label": "Number of adults accompanying a child"
+      },
       "detail-restrictions": {
         "label": "What you can and cannot do in the UK"
       },

--- a/apps/eec/translations/src/en/validation.json
+++ b/apps/eec/translations/src/en/validation.json
@@ -79,6 +79,9 @@
     "validateText": "Last name must contain only letters a to z, spaces, hyphens and apostrophes",
     "maxlength": "Enter a last name that is 120 characters or less"
   },
+  "how-many-adults": {
+    "required": "Choose how many adults are accompanying a child"
+  },
   "detail-restrictions": {
     "required": "Enter what is wrong with the details of what you can and cannot do in the UK",
     "maxlength": "You have exceeded the 500 character limit"


### PR DESCRIPTION
## What?

Added a new page enabling users to choose number of adults accompany a child.
This is completely a new option for problem checklist page too, so added a new checkbox in problem page.

Implemented conditional routing to navigate testers to the new page (this will be updated later as part of ticket EEC-149).

Current focus: the new page, validations, and the CYA page.

## Why?

EEC-175

## How?

## Testing?

## Screenshots (optional)

Option to navigate to the page

<img width="523" height="56" alt="image" src="https://github.com/user-attachments/assets/54842fd7-6108-47e0-b567-903ae1259a3f" />

With required validation

<img width="773" height="768" alt="image" src="https://github.com/user-attachments/assets/9229a557-84c8-46ae-b6c6-e00a9e42cbb1" />

CYA page

<img width="714" height="102" alt="image" src="https://github.com/user-attachments/assets/fe66bb27-e537-4c7c-9600-2fde0f3a8841" />


## Anything Else? (optional)

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
