### PR TITLE
EEC-152: Add new page to enter correct details of ship and port.

### DIFF
--- a/apps/eec/fields/index.js
+++ b/apps/eec/fields/index.js
@@ -202,6 +202,9 @@ module.exports = {
         value: 'problem-accompanying-adult-details'
       },
       {
+        value: 'problem-ship-and-port-details'
+      },
+      {
         value: 'problem-restrictions',
         toggle: 'detail-restrictions',
         child: 'textarea'
@@ -295,6 +298,12 @@ module.exports = {
     legend: {
       className: 'govuk-!-margin-bottom-6'
     }
+  },
+  'correct-ship-name': {
+    validate: 'required'
+  },
+  'correct-port-name': {
+    validate: 'required'
   },
   'detail-restrictions': {
     mixin: 'textarea',

--- a/apps/eec/index.js
+++ b/apps/eec/index.js
@@ -181,6 +181,11 @@ module.exports = {
           target: '/how-many-adults',
           condition: req => req.sessionModel.get('problem') &&
           req.sessionModel.get('problem').includes('problem-accompanying-adult-details')
+        },
+        {
+          target: '/correct-ship-and-port',
+          condition: req => req.sessionModel.get('problem') &&
+          req.sessionModel.get('problem').includes('problem-ship-and-port-details')
         }
       ],
       showNeedHelp: true
@@ -235,6 +240,14 @@ module.exports = {
     '/how-many-adults': {
       next: '/personal-details',
       fields: ['how-many-adults'],
+      showNeedHelp: true
+    },
+    '/correct-ship-and-port': {
+      next: '/personal-details',
+      fields: [
+        'correct-ship-name',
+        'correct-port-name'
+      ],
       showNeedHelp: true
     },
     '/personal-details': {

--- a/apps/eec/sections/summary-data-sections.js
+++ b/apps/eec/sections/summary-data-sections.js
@@ -92,6 +92,18 @@ module.exports = {
         field: 'how-many-adults'
       },
       {
+        step: '/correct-ship-and-port',
+        field: 'correct-ship-name',
+        parse: (val, req) => {
+          if (!req.sessionModel.get('steps').includes('/correct-ship-and-port')) {
+            return null;
+          }
+          const shipName = req.sessionModel.get('correct-ship-name');
+          const portName = req.sessionModel.get('correct-port-name');
+          return `${shipName}, ${portName}`;
+        }
+      },
+      {
         step: '/problem',
         field: 'detail-restrictions'
       },

--- a/apps/eec/translations/src/en/fields.json
+++ b/apps/eec/translations/src/en/fields.json
@@ -108,6 +108,9 @@
       "problem-accompanying-adult-details": {
         "label": "Name or passport numbers of accompanying adult"
       },
+      "problem-ship-and-port-details": {
+        "label": "Ship and port details"
+      },
       "problem-restrictions": {
         "label": "What you can and cannot do in the UK"
       },
@@ -183,6 +186,13 @@
         "label": "2 adults"
       }
     }
+  },
+  "correct-ship-name": {
+    "label": "Correct ship name"
+  },
+  "correct-port-name": {
+    "label": "Correct port",
+    "hint": "For example, Southampton port"
   },
   "detail-restrictions": {
     "label": "What is wrong with the details of what you can and cannot do in the UK?"

--- a/apps/eec/translations/src/en/pages.json
+++ b/apps/eec/translations/src/en/pages.json
@@ -48,6 +48,10 @@
     "header": "What is the correct name of your future partner?",
     "intro": "You must enter the same details that you used in your visa application."
   },
+  "correct-ship-and-port": {
+    "header": "What is the name of the ship and port you will leave the UK from?",
+    "intro": "You must enter the same details that you used in your visa application."
+  },
   "personal-details": {
     "header": "Personal details",
     "intro": "You must enter these details exactly as they appear on your eVisa so we can review the problem."
@@ -144,6 +148,9 @@
       },
       "how-many-adults": {
         "label": "Number of adults accompanying a child"
+      },
+      "correct-ship-name": {
+        "label": "Ship and port details"
       },
       "detail-restrictions": {
         "label": "What you can and cannot do in the UK"

--- a/apps/eec/translations/src/en/validation.json
+++ b/apps/eec/translations/src/en/validation.json
@@ -82,6 +82,12 @@
   "how-many-adults": {
     "required": "Choose how many adults are accompanying a child"
   },
+  "correct-ship-name": {
+    "required": "Enter the correct ship name"
+  },
+  "correct-port-name": {
+    "required": "Enter the correct port"
+  },
   "detail-restrictions": {
     "required": "Enter what is wrong with the details of what you can and cannot do in the UK",
     "maxlength": "You have exceeded the 500 character limit"


### PR DESCRIPTION
## What?
Added a new page enabling users to provide correct ship and port deatils.
This is completely a new option for problem checklist page too, so added a new checkbox in problem page.

Implemented conditional routing to navigate testers to the new page (this will be updated later as part of ticket EEC-149).

CYA page shows after concatenated both Ship name and port name and displayed as Ship and port details, which is checkbox field label from the problem page.

Current focus: the new page, validations, and the CYA page.

## Why?

EEC-152

## How?

## Testing?

## Screenshots (optional)

option in problem page

<img width="287" height="54" alt="image" src="https://github.com/user-attachments/assets/a3c022bc-0483-43de-90c4-e82199fea261" />

With required validation
<img width="609" height="797" alt="image" src="https://github.com/user-attachments/assets/254a9c3a-96ac-4134-968e-d8ff43eda6d0" />

CYA page

<img width="561" height="74" alt="image" src="https://github.com/user-attachments/assets/a644f80d-cc61-4866-9490-2fd43bc50208" />

## Anything Else? (optional)

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
