### PR TITLE
EEC-176: Add new page to enter details of the adult accompanying a child.

### DIFF
--- a/apps/eec/fields/index.js
+++ b/apps/eec/fields/index.js
@@ -305,6 +305,15 @@ module.exports = {
   'correct-port-name': {
     validate: 'required'
   },
+  'correct-given-names-adult-accompanying': {
+    validate: ['required', validateText, { type: 'maxlength', arguments: 120 }]
+  },
+  'correct-last-name-adult-accompanying': {
+    validate: ['required', validateText, { type: 'maxlength', arguments: 120 }]
+  },
+  'correct-passport-number-adult-accompanying': {
+    validate: ['required', 'alphanum']
+  },
   'detail-restrictions': {
     mixin: 'textarea',
     validate: ['required', { type: 'maxlength', arguments: 500 }],

--- a/apps/eec/index.js
+++ b/apps/eec/index.js
@@ -240,6 +240,24 @@ module.exports = {
     '/how-many-adults': {
       next: '/personal-details',
       fields: ['how-many-adults'],
+      showNeedHelp: true,
+      forks: [
+        {
+          target: '/correct-details-adult-accompanying',
+          condition: {
+            field: 'how-many-adults',
+            value: '1-adult'
+          }
+        }
+      ]
+    },
+    '/correct-details-adult-accompanying': {
+      next: '/personal-details',
+      fields: [
+        'correct-given-names-adult-accompanying',
+        'correct-last-name-adult-accompanying',
+        'correct-passport-number-adult-accompanying'
+      ],
       showNeedHelp: true
     },
     '/correct-ship-and-port': {

--- a/apps/eec/sections/summary-data-sections.js
+++ b/apps/eec/sections/summary-data-sections.js
@@ -104,6 +104,19 @@ module.exports = {
         }
       },
       {
+        step: '/correct-details-adult-accompanying',
+        field: 'correct-given-names-adult-accompanying',
+        parse: (val, req) => {
+          if (!req.sessionModel.get('steps').includes('/correct-details-adult-accompanying')) {
+            return null;
+          }
+          const givenNames = req.sessionModel.get('correct-given-names-adult-accompanying');
+          const lastName = req.sessionModel.get('correct-last-name-adult-accompanying');
+          const passportNumber = req.sessionModel.get('correct-passport-number-adult-accompanying');
+          return `${givenNames} ${lastName}, ${passportNumber}`;
+        }
+      },
+      {
         step: '/problem',
         field: 'detail-restrictions'
       },

--- a/apps/eec/sections/summary-data-sections.js
+++ b/apps/eec/sections/summary-data-sections.js
@@ -113,7 +113,7 @@ module.exports = {
           const givenNames = req.sessionModel.get('correct-given-names-adult-accompanying');
           const lastName = req.sessionModel.get('correct-last-name-adult-accompanying');
           const passportNumber = req.sessionModel.get('correct-passport-number-adult-accompanying');
-          return `${givenNames} ${lastName}, ${passportNumber}`;
+          return `${givenNames} ${lastName}\n${passportNumber}`;
         }
       },
       {

--- a/apps/eec/translations/src/en/fields.json
+++ b/apps/eec/translations/src/en/fields.json
@@ -194,6 +194,15 @@
     "label": "Correct port",
     "hint": "For example, Southampton port"
   },
+  "correct-given-names-adult-accompanying": {
+    "label": "Given names"
+  },
+  "correct-last-name-adult-accompanying": {
+    "label": "Last name"
+  },
+  "correct-passport-number-adult-accompanying": {
+    "label": "Passport number"
+  },
   "detail-restrictions": {
     "label": "What is wrong with the details of what you can and cannot do in the UK?"
   },

--- a/apps/eec/translations/src/en/pages.json
+++ b/apps/eec/translations/src/en/pages.json
@@ -52,6 +52,10 @@
     "header": "What is the name of the ship and port you will leave the UK from?",
     "intro": "You must enter the same details that you used in your visa application."
   },
+  "correct-details-adult-accompanying": {
+    "header": "What are the correct details of the adult accompanying the child?",
+    "intro": "You must enter the same details that you used in your visa application."
+  },
   "personal-details": {
     "header": "Personal details",
     "intro": "You must enter these details exactly as they appear on your eVisa so we can review the problem."
@@ -151,6 +155,9 @@
       },
       "correct-ship-name": {
         "label": "Ship and port details"
+      },
+      "correct-given-names-adult-accompanying": {
+        "label": "Name and passport number of accompanying adult"
       },
       "detail-restrictions": {
         "label": "What you can and cannot do in the UK"

--- a/apps/eec/translations/src/en/validation.json
+++ b/apps/eec/translations/src/en/validation.json
@@ -88,6 +88,20 @@
   "correct-port-name": {
     "required": "Enter the correct port"
   },
+  "correct-given-names-adult-accompanying": {
+    "required": "Enter their given names",
+    "validateText": "Given names must contain only letters a to z, spaces, hyphens and apostrophes",
+    "maxlength": "Enter given names that are 120 characters or less"
+  },
+  "correct-last-name-adult-accompanying": {
+    "required": "Enter their last name",
+    "validateText": "Last name must contain only letters a to z, spaces, hyphens and apostrophes",
+    "maxlength": "Enter a last name that is 120 characters or less"
+  },
+  "correct-passport-number-adult-accompanying": {
+    "required": "Enter a passport number",
+    "alphanum": "Passport number must only include letters a to z and numbers"
+  },
   "detail-restrictions": {
     "required": "Enter what is wrong with the details of what you can and cannot do in the UK",
     "maxlength": "You have exceeded the 500 character limit"


### PR DESCRIPTION
## What?

Added a new page enabling users to provide correct details of the adult accompanying a child.

Implemented conditional routing to navigate testers to the new page (this will be updated later as part of ticket EEC-149).

CYA page shows after concatenated Given names, Last name and Passport number and displayed as Name and passport number of accompanying adult.

Current focus: the new page, validations, and the CYA page.

## Why?

EEC-176

## How?

## Testing?

## Screenshots (optional)

With required validation

<img width="514" height="750" alt="image" src="https://github.com/user-attachments/assets/389403da-762f-414f-babb-c93346b72d31" />

With invalid char validation

<img width="476" height="651" alt="image" src="https://github.com/user-attachments/assets/30750000-445a-405e-a286-1b17316f0324" />

With max length validation

<img width="475" height="626" alt="image" src="https://github.com/user-attachments/assets/641b4581-9893-4cd5-a527-788f2f0fc6e0" />

CYA page

<img width="697" height="198" alt="image" src="https://github.com/user-attachments/assets/4ffc2a28-cb23-4450-9add-b3df1e017e1b" />


## Anything Else? (optional)

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
