### PR TITLE
EEC-182: Sponsor licence validation, new validations and updated validation messages

### DIFF
--- a/apps/eec/fields/index.js
+++ b/apps/eec/fields/index.js
@@ -268,7 +268,7 @@ module.exports = {
     ]
   },
   'correct-sponsor-licence-number': {
-    validate: 'required',
+    validate: ['required', 'alphanum', { type: 'maxlength', arguments: 20 }],
     formatter: ['removespaces']
   },
   photo: {

--- a/apps/eec/translations/src/en/validation.json
+++ b/apps/eec/translations/src/en/validation.json
@@ -64,7 +64,9 @@
     "regex" : "Enter a National Insurance number in the correct format"
   },
   "correct-sponsor-licence-number": {
-    "required": "Enter your sponsor licence number"
+    "required": "Enter your sponsor licence number",
+    "alphanum": "Sponsor licence number can only contain letters a to z or numbers 0 to 9",
+    "maxlength": "Sponsor licence number must be 20 characters or less"
   },
   "photo": {
     "required": "Describe the problem you are having"


### PR DESCRIPTION
## What?

New validations created/updated:

- Alphanumeric characters only validation
- Required validation
- Max-length of 20 characters validation

## Why?

As per business' request.

## How?

Altered parameters within HOF fields and validation messages within codebase.

## Testing?

Tested locally against each acceptance criteria.

## Screenshots (optional)

<img width="695" height="552" alt="Screenshot 2026-06-15 at 13 19 53" src="https://github.com/user-attachments/assets/50b53c90-bdd1-4c61-9a09-60b42ca713a6" />
<img width="692" height="604" alt="Screenshot 2026-06-15 at 13 19 47" src="https://github.com/user-attachments/assets/d5205688-0cbc-403d-a4b8-6de78a8e9ca4" />
<img width="703" height="552" alt="Screenshot 2026-06-15 at 13 19 28" src="https://github.com/user-attachments/assets/58bd4002-7fcb-4b4a-a87e-5a002b0e0df2" />

## Anything Else? (optional)

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
