### PR TITLE
EEC-153: Add page to enter flight number and airport details.

### DIFF
--- a/apps/eec/fields/index.js
+++ b/apps/eec/fields/index.js
@@ -205,6 +205,9 @@ module.exports = {
         value: 'problem-ship-and-port-details'
       },
       {
+        value: 'problem-flight-number-airport'
+      },
+      {
         value: 'problem-restrictions-in-uk'
       },
       {
@@ -311,6 +314,12 @@ module.exports = {
   },
   'correct-passport-number-adult-accompanying': {
     validate: ['required', 'alphanum']
+  },
+  'correct-flight-number': {
+    validate: 'required'
+  },
+  'correct-airport': {
+    validate: 'required'
   },
   'detail-restrictions-in-uk': {
     isPageHeading: 'true',

--- a/apps/eec/index.js
+++ b/apps/eec/index.js
@@ -190,6 +190,11 @@ module.exports = {
           target: '/details-can-do-uk',
           condition: req => req.sessionModel.get('problem') &&
           req.sessionModel.get('problem').includes('problem-restrictions-in-uk')
+        },
+        {
+          target: '/correct-flight-number-airport',
+          condition: req => req.sessionModel.get('problem') &&
+          req.sessionModel.get('problem').includes('problem-flight-number-airport')
         }
       ],
       showNeedHelp: true
@@ -275,6 +280,14 @@ module.exports = {
     '/details-can-do-uk': {
       next: '/personal-details',
       fields: ['detail-restrictions-in-uk'],
+      showNeedHelp: true
+    },
+    '/correct-flight-number-airport': {
+      next: '/personal-details',
+      fields: [
+        'correct-flight-number',
+        'correct-airport'
+      ],
       showNeedHelp: true
     },
     '/personal-details': {

--- a/apps/eec/sections/summary-data-sections.js
+++ b/apps/eec/sections/summary-data-sections.js
@@ -117,6 +117,18 @@ module.exports = {
         }
       },
       {
+        step: '/correct-flight-number-airport',
+        field: 'correct-flight-number',
+        parse: (val, req) => {
+          if (!req.sessionModel.get('steps').includes('/correct-flight-number-airport')) {
+            return null;
+          }
+          const flightNumber = req.sessionModel.get('correct-flight-number');
+          const airport = req.sessionModel.get('correct-airport');
+          return `${flightNumber}, ${airport}`;
+        }
+      },
+      {
         step: '/details-can-do-uk',
         field: 'detail-restrictions-in-uk'
       },

--- a/apps/eec/translations/src/en/fields.json
+++ b/apps/eec/translations/src/en/fields.json
@@ -111,6 +111,9 @@
       "problem-ship-and-port-details": {
         "label": "Ship and port details"
       },
+      "problem-flight-number-airport": {
+        "label": "Must leave UK via (flight number and airport)"
+      },
       "problem-restrictions-in-uk": {
         "label": "What you can and cannot do in the UK"
       },
@@ -202,6 +205,13 @@
   },
   "correct-passport-number-adult-accompanying": {
     "label": "Passport number"
+  },
+  "correct-flight-number": {
+    "label": "Correct flight number"
+  },
+  "correct-airport": {
+    "label": "Correct airport",
+    "hint": "For example, Heathrow Airport"
   },
   "detail-restrictions-in-uk": {
     "label": "What is wrong with the details of what you can and cannot do in the UK?"

--- a/apps/eec/translations/src/en/pages.json
+++ b/apps/eec/translations/src/en/pages.json
@@ -56,6 +56,10 @@
     "header": "What are the correct details of the adult accompanying the child?",
     "intro": "You must enter the same details that you used in your visa application."
   },
+  "correct-flight-number-airport": {
+    "header": "What is your flight number and the airport you will leave the UK from?",
+    "intro": "You must enter the same details that you used in your visa application."
+  },
   "personal-details": {
     "header": "Personal details",
     "intro": "You must enter these details exactly as they appear on your eVisa so we can review the problem."
@@ -158,6 +162,9 @@
       },
       "correct-given-names-adult-accompanying": {
         "label": "Name and passport number of accompanying adult"
+      },
+      "correct-flight-number": {
+        "label": "Must leave UK via (flight number and airport)"
       },
       "detail-restrictions-in-uk": {
         "label": "What you can and cannot do in the UK"

--- a/apps/eec/translations/src/en/validation.json
+++ b/apps/eec/translations/src/en/validation.json
@@ -104,6 +104,12 @@
     "required": "Enter a passport number",
     "alphanum": "Passport number must only include letters a to z and numbers"
   },
+  "correct-flight-number": {
+    "required": "Enter the correct flight number"
+  },
+  "correct-airport": {
+    "required": "Enter the correct airport"
+  },
   "detail-restrictions-in-uk": {
     "required": "Enter what is wrong with the details of what you can and cannot do in the UK",
     "maxlength": "Enter details that are 500 characters or less"


### PR DESCRIPTION
## What?
Added a new page enabling users to provide correct flight number and airport details that they will leave the UK from.
This is completely a new option for problem checklist page too, so added a new checkbox in problem page.

Implemented conditional routing to navigate testers to the new page (this will be updated later as part of ticket EEC-149).

CYA page shows after concatenated both flight number and airport name and displayed as  'Must leave UK via (flight number and airport)', which is checkbox field label from the problem page.

Current focus: the new page, validations, and the CYA page.

## Why?

EEC-153

## How?

## Testing?

## Screenshots (optional)

With required validation

<img width="574" height="786" alt="image" src="https://github.com/user-attachments/assets/72c24521-8656-4569-94e4-445e9c3d22e2" />

CYA page

<img width="554" height="94" alt="image" src="https://github.com/user-attachments/assets/4b9b9960-0120-4474-9e6c-97c5f725402a" />


## Anything Else? (optional)

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
