### PR TITLE
EEC-154: Add page to enter details of restrictions in the UK.

### DIFF
--- a/apps/eec/fields/index.js
+++ b/apps/eec/fields/index.js
@@ -205,9 +205,7 @@ module.exports = {
         value: 'problem-ship-and-port-details'
       },
       {
-        value: 'problem-restrictions',
-        toggle: 'detail-restrictions',
-        child: 'textarea'
+        value: 'problem-restrictions-in-uk'
       },
       {
         value: 'problem-share-code',
@@ -314,14 +312,11 @@ module.exports = {
   'correct-passport-number-adult-accompanying': {
     validate: ['required', 'alphanum']
   },
-  'detail-restrictions': {
+  'detail-restrictions-in-uk': {
+    isPageHeading: 'true',
     mixin: 'textarea',
     validate: ['required', { type: 'maxlength', arguments: 500 }],
-    attributes: [{ attribute: 'rows', value: 5 }],
-    dependent: {
-      field: 'problem',
-      value: 'problem-restrictions'
-    }
+    attributes: [{ attribute: 'rows', value: 5 }]
   },
   'detail-share-code': {
     mixin: 'input-text',

--- a/apps/eec/index.js
+++ b/apps/eec/index.js
@@ -125,7 +125,6 @@ module.exports = {
         'problem',
         'detail-valid-from',
         'detail-valid-until',
-        'detail-restrictions',
         'detail-share-code',
         'detail-signin-email',
         'detail-signin-phone',
@@ -186,6 +185,11 @@ module.exports = {
           target: '/correct-ship-and-port',
           condition: req => req.sessionModel.get('problem') &&
           req.sessionModel.get('problem').includes('problem-ship-and-port-details')
+        },
+        {
+          target: '/details-can-do-uk',
+          condition: req => req.sessionModel.get('problem') &&
+          req.sessionModel.get('problem').includes('problem-restrictions-in-uk')
         }
       ],
       showNeedHelp: true
@@ -266,6 +270,11 @@ module.exports = {
         'correct-ship-name',
         'correct-port-name'
       ],
+      showNeedHelp: true
+    },
+    '/details-can-do-uk': {
+      next: '/personal-details',
+      fields: ['detail-restrictions-in-uk'],
       showNeedHelp: true
     },
     '/personal-details': {

--- a/apps/eec/sections/summary-data-sections.js
+++ b/apps/eec/sections/summary-data-sections.js
@@ -117,8 +117,8 @@ module.exports = {
         }
       },
       {
-        step: '/problem',
-        field: 'detail-restrictions'
+        step: '/details-can-do-uk',
+        field: 'detail-restrictions-in-uk'
       },
       {
         step: '/problem',

--- a/apps/eec/translations/src/en/fields.json
+++ b/apps/eec/translations/src/en/fields.json
@@ -111,7 +111,7 @@
       "problem-ship-and-port-details": {
         "label": "Ship and port details"
       },
-      "problem-restrictions": {
+      "problem-restrictions-in-uk": {
         "label": "What you can and cannot do in the UK"
       },
       "problem-share-code": {
@@ -203,7 +203,7 @@
   "correct-passport-number-adult-accompanying": {
     "label": "Passport number"
   },
-  "detail-restrictions": {
+  "detail-restrictions-in-uk": {
     "label": "What is wrong with the details of what you can and cannot do in the UK?"
   },
   "detail-share-code": {

--- a/apps/eec/translations/src/en/pages.json
+++ b/apps/eec/translations/src/en/pages.json
@@ -159,7 +159,7 @@
       "correct-given-names-adult-accompanying": {
         "label": "Name and passport number of accompanying adult"
       },
-      "detail-restrictions": {
+      "detail-restrictions-in-uk": {
         "label": "What you can and cannot do in the UK"
       },
       "detail-share-code": {

--- a/apps/eec/translations/src/en/validation.json
+++ b/apps/eec/translations/src/en/validation.json
@@ -104,9 +104,9 @@
     "required": "Enter a passport number",
     "alphanum": "Passport number must only include letters a to z and numbers"
   },
-  "detail-restrictions": {
+  "detail-restrictions-in-uk": {
     "required": "Enter what is wrong with the details of what you can and cannot do in the UK",
-    "maxlength": "You have exceeded the 500 character limit"
+    "maxlength": "Enter details that are 500 characters or less"
   },
   "detail-share-code": {
     "required": "Enter which share code you are unable to create"


### PR DESCRIPTION
## What?
Added a new page enabling users to provide what is wrong with the details of what you can and cannot do in the UK.

Previously, this was handled by toggling the input box behaviour on the problem page; all of that legacy code has now been removed.

Implemented conditional routing to navigate testers to the new page (this will be updated later as part of ticket EEC-149).

Current focus: the new page, validations, and the CYA page.
## Why?

EEC-154

## How?

## Testing?

## Screenshots (optional)

With required validation

<img width="643" height="700" alt="image" src="https://github.com/user-attachments/assets/dd00563f-2177-43bf-af27-24da9b54f9b5" />

With maxlength validation

<img width="569" height="460" alt="image" src="https://github.com/user-attachments/assets/c913e77f-db82-46a3-b6ea-c42e8776dd51" />

CYA page

<img width="571" height="74" alt="image" src="https://github.com/user-attachments/assets/2ebf2942-8697-49a8-9127-9c1687ce6fae" />


## Anything Else? (optional)

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
