### PR TITLE
EEC-162: Addition to the accessibility statement wording

### DIFF
--- a/apps/eec/views/content/en/accessibility.md
+++ b/apps/eec/views/content/en/accessibility.md
@@ -41,6 +41,12 @@ On the start page and the privacy policy page, the screen reader does not read o
 
 If you find an issue that we have yet to identify, please contact us using one of the routes described in the ‘Reporting accessibility problems with this website’ section of this statement.
 
+### Conditionally revealed questions
+
+A question on the screen asking users for their current eVisa details is conditionally revealed when the user selects a checkbox. Users of assistive technologies are not always notified when these questions are shown or hidden. This means the name, role or value of content is not always communicated correctly to screen reader users, which fails [WCAG 2.2 success criterion 4.1.2 (Name, Role, Value)](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html).
+
+Usability testing that has been carried out on other services found that screen reader users did not have difficulty answering a conditionally revealed question, as long as it is kept simple. However, more complex conditionally revealed questions has confused users in testing.
+
 ### Disproportionate burden
 
 At this time, we have not made any disproportionate burden claims.

--- a/apps/eec/views/content/en/accessibility.md
+++ b/apps/eec/views/content/en/accessibility.md
@@ -39,13 +39,13 @@ The content listed below is non-accessible for the following reasons.
 On the start page and the privacy policy page, the screen reader does not read out links, where there are any, if the cursor hovers over the paragraph or sentence. The screen reader will read out the links if the keyboard is used to navigate the page. This does not meet the following WCAG standards and guidelines:
 2.4.4 - Link purpose in context
 
-If you find an issue that we have yet to identify, please contact us using one of the routes described in the ‘Reporting accessibility problems with this website’ section of this statement.
-
 ### Conditionally revealed questions
 
 A question on the screen asking users for their current eVisa details is conditionally revealed when the user selects a checkbox. Users of assistive technologies are not always notified when these questions are shown or hidden. This means the name, role or value of content is not always communicated correctly to screen reader users, which fails [WCAG 2.2 success criterion 4.1.2 (Name, Role, Value)](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html).
 
 Usability testing that has been carried out on other services found that screen reader users did not have difficulty answering a conditionally revealed question, as long as it is kept simple. However, more complex conditionally revealed questions has confused users in testing.
+
+If you find an issue that we have yet to identify, please contact us using one of the routes described in the ‘Reporting accessibility problems with this website’ section of this statement.
 
 ### Disproportionate burden
 


### PR DESCRIPTION
## What?

Addition to the accessibility statement regarding conditionally revealed questions

## Why?

WCAG compliance.

## How?

Change made to the markdown file in which the accessibility page gets its content

## Testing?

Tested locally against all 3 acceptance criteria.

## Screenshots (optional)

<img width="716" height="746" alt="image" src="https://github.com/user-attachments/assets/0f41597b-fb68-47bb-9f92-178760c44e2d" />

## Anything Else? (optional)

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
