### PR TITLE
EEC-151: Add page to enter correct passport numbers.

### DIFF
--- a/apps/eec/fields/index.js
+++ b/apps/eec/fields/index.js
@@ -321,6 +321,12 @@ module.exports = {
   'correct-airport': {
     validate: 'required'
   },
+  'correct-passport-number-adult-1': {
+    validate: ['required', 'alphanum']
+  },
+  'correct-passport-number-adult-2': {
+    validate: ['required', 'alphanum']
+  },
   'detail-restrictions-in-uk': {
     isPageHeading: 'true',
     mixin: 'textarea',

--- a/apps/eec/index.js
+++ b/apps/eec/index.js
@@ -257,6 +257,13 @@ module.exports = {
             field: 'how-many-adults',
             value: '1-adult'
           }
+        },
+        {
+          target: '/correct-passport-number',
+          condition: {
+            field: 'how-many-adults',
+            value: '2-adults'
+          }
         }
       ]
     },
@@ -266,6 +273,14 @@ module.exports = {
         'correct-given-names-adult-accompanying',
         'correct-last-name-adult-accompanying',
         'correct-passport-number-adult-accompanying'
+      ],
+      showNeedHelp: true
+    },
+    '/correct-passport-number': {
+      next: '/personal-details',
+      fields: [
+        'correct-passport-number-adult-1',
+        'correct-passport-number-adult-2'
       ],
       showNeedHelp: true
     },

--- a/apps/eec/sections/summary-data-sections.js
+++ b/apps/eec/sections/summary-data-sections.js
@@ -129,6 +129,18 @@ module.exports = {
         }
       },
       {
+        step: '/correct-passport-number',
+        field: 'correct-passport-number-adult-1',
+        parse: (val, req) => {
+          if (!req.sessionModel.get('steps').includes('/correct-passport-number')) {
+            return null;
+          }
+          const passportNumber1 = req.sessionModel.get('correct-passport-number-adult-1');
+          const passportNumber2 = req.sessionModel.get('correct-passport-number-adult-2');
+          return `Adult 1: ${passportNumber1}\nAdult 2: ${passportNumber2}`;
+        }
+      },
+      {
         step: '/details-can-do-uk',
         field: 'detail-restrictions-in-uk'
       },

--- a/apps/eec/translations/src/en/fields.json
+++ b/apps/eec/translations/src/en/fields.json
@@ -213,6 +213,12 @@
     "label": "Correct airport",
     "hint": "For example, Heathrow Airport"
   },
+  "correct-passport-number-adult-1": {
+    "label": "Passport number of adult 1"
+  },
+  "correct-passport-number-adult-2": {
+    "label": "Passport number of adult 2"
+  },
   "detail-restrictions-in-uk": {
     "label": "What is wrong with the details of what you can and cannot do in the UK?"
   },

--- a/apps/eec/translations/src/en/pages.json
+++ b/apps/eec/translations/src/en/pages.json
@@ -48,7 +48,7 @@
     "header": "What is the correct name of your future partner?",
     "intro": "You must enter the same details that you used in your visa application."
   },
-      "correct-ship-and-port": {
+  "correct-ship-and-port": {
     "header": "What is the name of the ship and port you will leave the UK from?",
     "intro": "You must enter the same details that you used in your visa application."
   },

--- a/apps/eec/translations/src/en/pages.json
+++ b/apps/eec/translations/src/en/pages.json
@@ -48,7 +48,7 @@
     "header": "What is the correct name of your future partner?",
     "intro": "You must enter the same details that you used in your visa application."
   },
-  "correct-ship-and-port": {
+      "correct-ship-and-port": {
     "header": "What is the name of the ship and port you will leave the UK from?",
     "intro": "You must enter the same details that you used in your visa application."
   },
@@ -58,6 +58,10 @@
   },
   "correct-flight-number-airport": {
     "header": "What is your flight number and the airport you will leave the UK from?",
+    "intro": "You must enter the same details that you used in your visa application."
+  },
+  "correct-passport-number": {
+    "header": "What are the correct passport numbers of the adults approved to accompany a child?",
     "intro": "You must enter the same details that you used in your visa application."
   },
   "personal-details": {
@@ -165,6 +169,9 @@
       },
       "correct-flight-number": {
         "label": "Must leave UK via (flight number and airport)"
+      },
+      "correct-passport-number-adult-1": {
+        "label": "Passport numbers of accompanying adults"
       },
       "detail-restrictions-in-uk": {
         "label": "What you can and cannot do in the UK"

--- a/apps/eec/translations/src/en/validation.json
+++ b/apps/eec/translations/src/en/validation.json
@@ -110,6 +110,14 @@
   "correct-airport": {
     "required": "Enter the correct airport"
   },
+  "correct-passport-number-adult-1": {
+    "required": "Enter a passport number",
+    "alphanum": "Passport number must only include letters a to z and numbers"
+  },
+  "correct-passport-number-adult-2": {
+    "required": "Enter a passport number",
+    "alphanum": "Passport number must only include letters a to z and numbers"
+  },
   "detail-restrictions-in-uk": {
     "required": "Enter what is wrong with the details of what you can and cannot do in the UK",
     "maxlength": "Enter details that are 500 characters or less"


### PR DESCRIPTION
## What?

Added a new page enabling users to provide correct passport numbers of the adults approved to accompanying a child.

Implemented conditional routing to navigate testers to the new page (this will be updated later as part of ticket EEC-149).

CYA page shows after concatenated Adult 1 and 2 along with their Passport numbers in 2 lines and displayed as passport numbers of accompanying adults.

Current focus: the new page, validations, and the CYA page.

## Why?

EEC-151

## How?

## Testing?

## Screenshots (optional)

With required validation

<img width="585" height="803" alt="image" src="https://github.com/user-attachments/assets/8e85135e-a77b-4c95-be2b-edb2714d7a5f" />

With aplhanumeric validation

<img width="566" height="604" alt="image" src="https://github.com/user-attachments/assets/75db2ce4-5c45-4469-8b4f-f577a7751db7" />

CYA page

<img width="692" height="102" alt="image" src="https://github.com/user-attachments/assets/b7c2e9c6-625a-436b-a5f8-9faa6cd288a5" />

## Anything Else? (optional)

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
