### PR TITLE
EEC-155: Add page to enter problems about share code.

### DIFF
--- a/apps/eec/fields/index.js
+++ b/apps/eec/fields/index.js
@@ -211,9 +211,7 @@ module.exports = {
         value: 'problem-restrictions-in-uk'
       },
       {
-        value: 'problem-share-code',
-        toggle: 'detail-share-code',
-        child: 'input-text'
+        value: 'problem-share-code'
       },
       {
         value: 'problem-signin-email',
@@ -334,13 +332,8 @@ module.exports = {
     attributes: [{ attribute: 'rows', value: 5 }]
   },
   'detail-share-code': {
-    mixin: 'input-text',
-    validate: 'required',
-    className: ['govuk-input', 'govuk-!-width-two-thirds'],
-    dependent: {
-      field: 'problem',
-      value: 'problem-share-code'
-    }
+    isPageHeading: 'true',
+    validate: ['required', { type: 'maxlength', arguments: 200 }]
   },
   'detail-valid-from': {
     mixin: 'input-text',

--- a/apps/eec/index.js
+++ b/apps/eec/index.js
@@ -125,7 +125,6 @@ module.exports = {
         'problem',
         'detail-valid-from',
         'detail-valid-until',
-        'detail-share-code',
         'detail-signin-email',
         'detail-signin-phone',
         'detail-other'
@@ -195,6 +194,11 @@ module.exports = {
           target: '/correct-flight-number-airport',
           condition: req => req.sessionModel.get('problem') &&
           req.sessionModel.get('problem').includes('problem-flight-number-airport')
+        },
+        {
+          target: '/share-code',
+          condition: req => req.sessionModel.get('problem') &&
+          req.sessionModel.get('problem').includes('problem-share-code')
         }
       ],
       showNeedHelp: true
@@ -303,6 +307,11 @@ module.exports = {
         'correct-flight-number',
         'correct-airport'
       ],
+      showNeedHelp: true
+    },
+    '/share-code': {
+      next: '/personal-details',
+      fields: ['detail-share-code'],
       showNeedHelp: true
     },
     '/personal-details': {

--- a/apps/eec/sections/summary-data-sections.js
+++ b/apps/eec/sections/summary-data-sections.js
@@ -145,7 +145,7 @@ module.exports = {
         field: 'detail-restrictions-in-uk'
       },
       {
-        step: '/problem',
+        step: '/share-code',
         field: 'detail-share-code'
       },
       {

--- a/apps/eec/translations/src/en/fields.json
+++ b/apps/eec/translations/src/en/fields.json
@@ -224,7 +224,7 @@
   },
   "detail-share-code": {
     "label": "Which share code are you unable to create?",
-    "hint": "This could be for right to work, right to rent or something else"
+    "hint": "This could be right to work, right to rent or something else"
   },
   "detail-valid-from": {
     "label": "What is the correct date your visa is valid from?"

--- a/apps/eec/translations/src/en/fields.json
+++ b/apps/eec/translations/src/en/fields.json
@@ -224,7 +224,7 @@
   },
   "detail-share-code": {
     "label": "Which share code are you unable to create?",
-    "hint": "This could be right to work, right to rent or something else"
+    "hint": "This could be for right to work, right to rent or something else"
   },
   "detail-valid-from": {
     "label": "What is the correct date your visa is valid from?"

--- a/apps/eec/translations/src/en/validation.json
+++ b/apps/eec/translations/src/en/validation.json
@@ -123,7 +123,8 @@
     "maxlength": "Enter details that are 500 characters or less"
   },
   "detail-share-code": {
-    "required": "Enter which share code you are unable to create"
+    "required": "Enter which share code you are unable to create",
+    "maxlength": "Enter details that are 200 characters or less"
   },
   "detail-valid-from": {
     "required": "Enter the correct valid from date"


### PR DESCRIPTION
## What?
Added a new page enabling users to provide details of share code which is unable to create.

Previously, this was handled by toggling the input box behaviour on the problem page; all of that legacy code has now been removed.

Implemented conditional routing to navigate testers to the new page (this will be updated later as part of ticket EEC-149).

Current focus: the new page, validations, and the CYA page.
## Why?
EEC-155
## How?

## Testing?

## Screenshots (optional)

With required validation

<img width="728" height="745" alt="image" src="https://github.com/user-attachments/assets/babaf6b9-3c45-4adf-86bd-b7fc7e648fd5" />

With Maxlength validation

<img width="689" height="513" alt="image" src="https://github.com/user-attachments/assets/9f11b9ad-c8a6-4506-bf8d-454de6aa3858" />

CYA page

<img width="710" height="90" alt="image" src="https://github.com/user-attachments/assets/e44e0f67-10d4-4fad-93b6-621866218ca2" />


## Anything Else? (optional)

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
