### PR TITLE
EEC-166: Add page to enter the correct date of visa is valid from.

### DIFF
--- a/apps/eec/fields/index.js
+++ b/apps/eec/fields/index.js
@@ -177,7 +177,7 @@ module.exports = {
         value: 'problem-status'
       },
       {
-        value: 'problem-date-valid-from'
+        value: 'problem-valid-from-date'
       },
       {
         value: 'problem-valid-until',
@@ -254,7 +254,7 @@ module.exports = {
     isPageHeading: 'true',
     validate: 'required'
   },
-  'correct-date-valid-from': dateComponent('correct-date-valid-from', {
+  'correct-valid-from-date': dateComponent('correct-valid-from-date', {
     isPageHeading: 'true',
     mixin: 'input-date',
     validate: [

--- a/apps/eec/fields/index.js
+++ b/apps/eec/fields/index.js
@@ -177,9 +177,7 @@ module.exports = {
         value: 'problem-status'
       },
       {
-        value: 'problem-valid-from',
-        toggle: 'detail-valid-from',
-        child: 'input-text'
+        value: 'problem-date-valid-from'
       },
       {
         value: 'problem-valid-until',
@@ -256,6 +254,14 @@ module.exports = {
     isPageHeading: 'true',
     validate: 'required'
   },
+  'correct-date-valid-from': dateComponent('correct-date-valid-from', {
+    isPageHeading: 'true',
+    mixin: 'input-date',
+    validate: [
+      'required',
+      'date'
+    ]
+  }),
   'correct-national-insurance-number': {
     formatter: ['removespaces', 'uppercase'],
     attributes: [
@@ -334,15 +340,6 @@ module.exports = {
   'detail-share-code': {
     isPageHeading: 'true',
     validate: ['required', { type: 'maxlength', arguments: 200 }]
-  },
-  'detail-valid-from': {
-    mixin: 'input-text',
-    validate: 'required',
-    className: ['govuk-input', 'govuk-!-width-one-third'],
-    dependent: {
-      field: 'problem',
-      value: 'problem-valid-from'
-    }
   },
   'detail-valid-until': {
     mixin: 'input-text',

--- a/apps/eec/fields/index.js
+++ b/apps/eec/fields/index.js
@@ -254,7 +254,7 @@ module.exports = {
     isPageHeading: 'true',
     validate: 'required'
   },
-  'correct-valid-from': dateComponent('correct-valid-from', {
+  'correct-visa-date': dateComponent('correct-visa-date', {
     isPageHeading: 'true',
     mixin: 'input-date',
     validate: [

--- a/apps/eec/fields/index.js
+++ b/apps/eec/fields/index.js
@@ -177,7 +177,7 @@ module.exports = {
         value: 'problem-status'
       },
       {
-        value: 'problem-valid-from-date'
+        value: 'problem-valid-from'
       },
       {
         value: 'problem-valid-until',
@@ -254,7 +254,7 @@ module.exports = {
     isPageHeading: 'true',
     validate: 'required'
   },
-  'correct-valid-from-date': dateComponent('correct-valid-from-date', {
+  'correct-valid-from': dateComponent('correct-valid-from', {
     isPageHeading: 'true',
     mixin: 'input-date',
     validate: [

--- a/apps/eec/fields/index.js
+++ b/apps/eec/fields/index.js
@@ -254,7 +254,7 @@ module.exports = {
     isPageHeading: 'true',
     validate: 'required'
   },
-  'correct-visa-date': dateComponent('correct-visa-date', {
+  'correct-visa-date-from': dateComponent('correct-visa-date-from', {
     isPageHeading: 'true',
     mixin: 'input-date',
     validate: [

--- a/apps/eec/fields/index.js
+++ b/apps/eec/fields/index.js
@@ -254,7 +254,7 @@ module.exports = {
     isPageHeading: 'true',
     validate: 'required'
   },
-  'correct-visa-date-from': dateComponent('correct-visa-date-from', {
+  'correct-visa-start-date': dateComponent('correct-visa-start-date', {
     isPageHeading: 'true',
     mixin: 'input-date',
     validate: [

--- a/apps/eec/index.js
+++ b/apps/eec/index.js
@@ -155,7 +155,7 @@ module.exports = {
           req.sessionModel.get('problem').includes('problem-status')
         },
         {
-          target: '/correct-visa-date',
+          target: '/date-valid-from',
           condition: req => req.sessionModel.get('problem') &&
           req.sessionModel.get('problem').includes('problem-valid-from')
         },
@@ -231,7 +231,7 @@ module.exports = {
       fields: ['problem-immigration-status'],
       showNeedHelp: true
     },
-    '/correct-visa-date': {
+    '/date-valid-from': {
       next: '/personal-details',
       fields: ['correct-visa-date'],
       showNeedHelp: true

--- a/apps/eec/index.js
+++ b/apps/eec/index.js
@@ -123,7 +123,6 @@ module.exports = {
       next: '/personal-details',
       fields: [
         'problem',
-        'detail-valid-from',
         'detail-valid-until',
         'detail-signin-email',
         'detail-signin-phone',
@@ -154,6 +153,11 @@ module.exports = {
           target: '/problem-immigration-status',
           condition: req => req.sessionModel.get('problem') &&
           req.sessionModel.get('problem').includes('problem-status')
+        },
+        {
+          target: '/date-valid-from',
+          condition: req => req.sessionModel.get('problem') &&
+          req.sessionModel.get('problem').includes('problem-date-valid-from')
         },
         {
           target: '/national-insurance-number',
@@ -225,6 +229,11 @@ module.exports = {
     '/problem-immigration-status': {
       next: '/personal-details',
       fields: ['problem-immigration-status'],
+      showNeedHelp: true
+    },
+    '/date-valid-from': {
+      next: '/personal-details',
+      fields: ['correct-date-valid-from'],
       showNeedHelp: true
     },
     '/national-insurance-number': {

--- a/apps/eec/index.js
+++ b/apps/eec/index.js
@@ -155,7 +155,7 @@ module.exports = {
           req.sessionModel.get('problem').includes('problem-status')
         },
         {
-          target: '/correct-date-valid-from',
+          target: '/correct-valid-from',
           condition: req => req.sessionModel.get('problem') &&
           req.sessionModel.get('problem').includes('problem-valid-from')
         },
@@ -231,7 +231,7 @@ module.exports = {
       fields: ['problem-immigration-status'],
       showNeedHelp: true
     },
-    '/correct-date-valid-from': {
+    '/correct-valid-from': {
       next: '/personal-details',
       fields: ['correct-valid-from'],
       showNeedHelp: true

--- a/apps/eec/index.js
+++ b/apps/eec/index.js
@@ -233,7 +233,7 @@ module.exports = {
     },
     '/date-valid-from': {
       next: '/personal-details',
-      fields: ['correct-visa-date-from'],
+      fields: ['correct-visa-start-date'],
       showNeedHelp: true
     },
     '/national-insurance-number': {

--- a/apps/eec/index.js
+++ b/apps/eec/index.js
@@ -157,7 +157,7 @@ module.exports = {
         {
           target: '/date-valid-from',
           condition: req => req.sessionModel.get('problem') &&
-          req.sessionModel.get('problem').includes('problem-date-valid-from')
+          req.sessionModel.get('problem').includes('problem-valid-from-date')
         },
         {
           target: '/national-insurance-number',
@@ -233,7 +233,7 @@ module.exports = {
     },
     '/date-valid-from': {
       next: '/personal-details',
-      fields: ['correct-date-valid-from'],
+      fields: ['correct-valid-from-date'],
       showNeedHelp: true
     },
     '/national-insurance-number': {

--- a/apps/eec/index.js
+++ b/apps/eec/index.js
@@ -157,7 +157,7 @@ module.exports = {
         {
           target: '/date-valid-from',
           condition: req => req.sessionModel.get('problem') &&
-          req.sessionModel.get('problem').includes('problem-valid-from-date')
+          req.sessionModel.get('problem').includes('problem-valid-from')
         },
         {
           target: '/national-insurance-number',
@@ -233,7 +233,7 @@ module.exports = {
     },
     '/date-valid-from': {
       next: '/personal-details',
-      fields: ['correct-valid-from-date'],
+      fields: ['correct-valid-from'],
       showNeedHelp: true
     },
     '/national-insurance-number': {

--- a/apps/eec/index.js
+++ b/apps/eec/index.js
@@ -155,7 +155,7 @@ module.exports = {
           req.sessionModel.get('problem').includes('problem-status')
         },
         {
-          target: '/correct-visa-from-date',
+          target: '/correct-visa-date',
           condition: req => req.sessionModel.get('problem') &&
           req.sessionModel.get('problem').includes('problem-valid-from')
         },
@@ -231,9 +231,9 @@ module.exports = {
       fields: ['problem-immigration-status'],
       showNeedHelp: true
     },
-    '/correct-visa-from-date': {
+    '/correct-visa-date': {
       next: '/personal-details',
-      fields: ['correct-valid-from'],
+      fields: ['correct-visa-date'],
       showNeedHelp: true
     },
     '/national-insurance-number': {

--- a/apps/eec/index.js
+++ b/apps/eec/index.js
@@ -233,7 +233,7 @@ module.exports = {
     },
     '/date-valid-from': {
       next: '/personal-details',
-      fields: ['correct-visa-date'],
+      fields: ['correct-visa-date-from'],
       showNeedHelp: true
     },
     '/national-insurance-number': {

--- a/apps/eec/index.js
+++ b/apps/eec/index.js
@@ -155,7 +155,7 @@ module.exports = {
           req.sessionModel.get('problem').includes('problem-status')
         },
         {
-          target: '/correct-valid-from',
+          target: '/correct-visa-from-date',
           condition: req => req.sessionModel.get('problem') &&
           req.sessionModel.get('problem').includes('problem-valid-from')
         },
@@ -231,7 +231,7 @@ module.exports = {
       fields: ['problem-immigration-status'],
       showNeedHelp: true
     },
-    '/correct-valid-from': {
+    '/correct-visa-from-date': {
       next: '/personal-details',
       fields: ['correct-valid-from'],
       showNeedHelp: true

--- a/apps/eec/index.js
+++ b/apps/eec/index.js
@@ -155,7 +155,7 @@ module.exports = {
           req.sessionModel.get('problem').includes('problem-status')
         },
         {
-          target: '/date-valid-from',
+          target: '/correct-date-valid-from',
           condition: req => req.sessionModel.get('problem') &&
           req.sessionModel.get('problem').includes('problem-valid-from')
         },
@@ -231,7 +231,7 @@ module.exports = {
       fields: ['problem-immigration-status'],
       showNeedHelp: true
     },
-    '/date-valid-from': {
+    '/correct-date-valid-from': {
       next: '/personal-details',
       fields: ['correct-valid-from'],
       showNeedHelp: true

--- a/apps/eec/sections/summary-data-sections.js
+++ b/apps/eec/sections/summary-data-sections.js
@@ -56,7 +56,7 @@ module.exports = {
         field: 'problem-immigration-status'
       },
       {
-        step: '/date-valid-from',
+        step: '/correct-date-valid-from',
         field: 'correct-valid-from',
         parse: val => !val ? '' : formatDate(val)
       },

--- a/apps/eec/sections/summary-data-sections.js
+++ b/apps/eec/sections/summary-data-sections.js
@@ -56,7 +56,7 @@ module.exports = {
         field: 'problem-immigration-status'
       },
       {
-        step: '/correct-date-valid-from',
+        step: '/correct-valid-from',
         field: 'correct-valid-from',
         parse: val => !val ? '' : formatDate(val)
       },

--- a/apps/eec/sections/summary-data-sections.js
+++ b/apps/eec/sections/summary-data-sections.js
@@ -56,8 +56,8 @@ module.exports = {
         field: 'problem-immigration-status'
       },
       {
-        step: '/correct-visa-from-date',
-        field: 'correct-valid-from',
+        step: '/correct-visa-date',
+        field: 'correct-visa-date',
         parse: val => !val ? '' : formatDate(val)
       },
       {

--- a/apps/eec/sections/summary-data-sections.js
+++ b/apps/eec/sections/summary-data-sections.js
@@ -57,7 +57,7 @@ module.exports = {
       },
       {
         step: '/date-valid-from',
-        field: 'correct-date-valid-from',
+        field: 'correct-valid-from-date',
         parse: val => !val ? '' : formatDate(val)
       },
       {

--- a/apps/eec/sections/summary-data-sections.js
+++ b/apps/eec/sections/summary-data-sections.js
@@ -56,7 +56,7 @@ module.exports = {
         field: 'problem-immigration-status'
       },
       {
-        step: '/correct-visa-date',
+        step: '/date-valid-from',
         field: 'correct-visa-date',
         parse: val => !val ? '' : formatDate(val)
       },

--- a/apps/eec/sections/summary-data-sections.js
+++ b/apps/eec/sections/summary-data-sections.js
@@ -57,7 +57,7 @@ module.exports = {
       },
       {
         step: '/date-valid-from',
-        field: 'correct-visa-date-from',
+        field: 'correct-visa-start-date',
         parse: val => !val ? '' : formatDate(val)
       },
       {

--- a/apps/eec/sections/summary-data-sections.js
+++ b/apps/eec/sections/summary-data-sections.js
@@ -56,7 +56,7 @@ module.exports = {
         field: 'problem-immigration-status'
       },
       {
-        step: '/correct-valid-from',
+        step: '/correct-visa-from-date',
         field: 'correct-valid-from',
         parse: val => !val ? '' : formatDate(val)
       },

--- a/apps/eec/sections/summary-data-sections.js
+++ b/apps/eec/sections/summary-data-sections.js
@@ -57,7 +57,7 @@ module.exports = {
       },
       {
         step: '/date-valid-from',
-        field: 'correct-visa-date',
+        field: 'correct-visa-date-from',
         parse: val => !val ? '' : formatDate(val)
       },
       {

--- a/apps/eec/sections/summary-data-sections.js
+++ b/apps/eec/sections/summary-data-sections.js
@@ -56,8 +56,9 @@ module.exports = {
         field: 'problem-immigration-status'
       },
       {
-        step: '/problem',
-        field: 'detail-valid-from'
+        step: '/date-valid-from',
+        field: 'correct-date-valid-from',
+        parse: val => !val ? '' : formatDate(val)
       },
       {
         step: '/problem',

--- a/apps/eec/sections/summary-data-sections.js
+++ b/apps/eec/sections/summary-data-sections.js
@@ -57,7 +57,7 @@ module.exports = {
       },
       {
         step: '/date-valid-from',
-        field: 'correct-valid-from-date',
+        field: 'correct-valid-from',
         parse: val => !val ? '' : formatDate(val)
       },
       {

--- a/apps/eec/translations/src/en/fields.json
+++ b/apps/eec/translations/src/en/fields.json
@@ -123,7 +123,7 @@
       "problem-status": {
         "label": "Status"
       },
-      "problem-valid-from-date": {
+      "problem-valid-from": {
         "label": "Valid from"
       },
       "problem-valid-until": {
@@ -163,7 +163,7 @@
     "label": "What problem are you having with your immigration status?",
     "hint": "This could be because your status is old, incorrect or you cannot view it"
   },
-  "correct-valid-from-date": {
+  "correct-valid-from": {
     "legend": "What is the correct date your visa is valid from?",
     "hint": "Enter date in the format DD MM YYYY"
   },

--- a/apps/eec/translations/src/en/fields.json
+++ b/apps/eec/translations/src/en/fields.json
@@ -123,7 +123,7 @@
       "problem-status": {
         "label": "Status"
       },
-      "problem-valid-from": {
+      "problem-date-valid-from": {
         "label": "Valid from"
       },
       "problem-valid-until": {
@@ -162,6 +162,10 @@
   "problem-immigration-status": {
     "label": "What problem are you having with your immigration status?",
     "hint": "This could be because your status is old, incorrect or you cannot view it"
+  },
+  "correct-date-valid-from": {
+    "legend": "What is the correct date your visa is valid from?",
+    "hint": "Enter date in the format DD MM YYYY"
   },
   "correct-national-insurance-number": {
     "label": "National Insurance number",
@@ -225,9 +229,6 @@
   "detail-share-code": {
     "label": "Which share code are you unable to create?",
     "hint": "This could be for right to work, right to rent or something else"
-  },
-  "detail-valid-from": {
-    "label": "What is the correct date your visa is valid from?"
   },
   "detail-valid-until": {
     "label": "What is the correct date your visa is valid to?"

--- a/apps/eec/translations/src/en/fields.json
+++ b/apps/eec/translations/src/en/fields.json
@@ -123,7 +123,7 @@
       "problem-status": {
         "label": "Status"
       },
-      "problem-date-valid-from": {
+      "problem-valid-from-date": {
         "label": "Valid from"
       },
       "problem-valid-until": {
@@ -163,7 +163,7 @@
     "label": "What problem are you having with your immigration status?",
     "hint": "This could be because your status is old, incorrect or you cannot view it"
   },
-  "correct-date-valid-from": {
+  "correct-valid-from-date": {
     "legend": "What is the correct date your visa is valid from?",
     "hint": "Enter date in the format DD MM YYYY"
   },

--- a/apps/eec/translations/src/en/fields.json
+++ b/apps/eec/translations/src/en/fields.json
@@ -163,7 +163,7 @@
     "label": "What problem are you having with your immigration status?",
     "hint": "This could be because your status is old, incorrect or you cannot view it"
   },
-  "correct-visa-date-from": {
+  "correct-visa-start-date": {
     "legend": "What is the correct date your visa is valid from?",
     "hint": "Enter date in the format DD MM YYYY"
   },

--- a/apps/eec/translations/src/en/fields.json
+++ b/apps/eec/translations/src/en/fields.json
@@ -96,6 +96,9 @@
       "problem-nationality": {
         "label": "Nationality"
       },
+      "problem-valid-from": {
+        "label": "Valid from"
+      },
       "problem-national-insurance-number": {
         "label": "National Insurance number"
       },
@@ -122,9 +125,6 @@
       },
       "problem-status": {
         "label": "Status"
-      },
-      "problem-valid-from": {
-        "label": "Valid from"
       },
       "problem-valid-until": {
         "label": "Valid to"

--- a/apps/eec/translations/src/en/fields.json
+++ b/apps/eec/translations/src/en/fields.json
@@ -163,7 +163,7 @@
     "label": "What problem are you having with your immigration status?",
     "hint": "This could be because your status is old, incorrect or you cannot view it"
   },
-  "correct-valid-from": {
+  "correct-visa-date": {
     "legend": "What is the correct date your visa is valid from?",
     "hint": "Enter date in the format DD MM YYYY"
   },

--- a/apps/eec/translations/src/en/fields.json
+++ b/apps/eec/translations/src/en/fields.json
@@ -163,7 +163,7 @@
     "label": "What problem are you having with your immigration status?",
     "hint": "This could be because your status is old, incorrect or you cannot view it"
   },
-  "correct-visa-date": {
+  "correct-visa-date-from": {
     "legend": "What is the correct date your visa is valid from?",
     "hint": "Enter date in the format DD MM YYYY"
   },

--- a/apps/eec/translations/src/en/pages.json
+++ b/apps/eec/translations/src/en/pages.json
@@ -146,7 +146,7 @@
       "problem-immigration-status": {
         "label": "Status"
       },
-      "correct-visa-date-from": {
+      "correct-visa-start-date": {
         "label": "Valid from"
       },
       "correct-national-insurance-number": {

--- a/apps/eec/translations/src/en/pages.json
+++ b/apps/eec/translations/src/en/pages.json
@@ -146,7 +146,7 @@
       "problem-immigration-status": {
         "label": "Status"
       },
-      "correct-valid-from": {
+      "correct-visa-date": {
         "label": "Valid from"
       },
       "correct-national-insurance-number": {

--- a/apps/eec/translations/src/en/pages.json
+++ b/apps/eec/translations/src/en/pages.json
@@ -146,6 +146,9 @@
       "problem-immigration-status": {
         "label": "Status"
       },
+      "correct-date-valid-from": {
+        "label": "Valid from"
+      },
       "correct-national-insurance-number": {
         "label": "National Insurance number"
       },
@@ -178,9 +181,6 @@
       },
       "detail-share-code": {
         "label": "Share code"
-      },
-      "detail-valid-from": {
-        "label": "Valid from"
       },
       "detail-valid-until": {
         "label": "Valid to"

--- a/apps/eec/translations/src/en/pages.json
+++ b/apps/eec/translations/src/en/pages.json
@@ -146,7 +146,7 @@
       "problem-immigration-status": {
         "label": "Status"
       },
-      "correct-visa-date": {
+      "correct-visa-date-from": {
         "label": "Valid from"
       },
       "correct-national-insurance-number": {

--- a/apps/eec/translations/src/en/pages.json
+++ b/apps/eec/translations/src/en/pages.json
@@ -146,7 +146,7 @@
       "problem-immigration-status": {
         "label": "Status"
       },
-      "correct-valid-from-date": {
+      "correct-valid-from": {
         "label": "Valid from"
       },
       "correct-national-insurance-number": {

--- a/apps/eec/translations/src/en/pages.json
+++ b/apps/eec/translations/src/en/pages.json
@@ -146,7 +146,7 @@
       "problem-immigration-status": {
         "label": "Status"
       },
-      "correct-date-valid-from": {
+      "correct-valid-from-date": {
         "label": "Valid from"
       },
       "correct-national-insurance-number": {

--- a/apps/eec/translations/src/en/validation.json
+++ b/apps/eec/translations/src/en/validation.json
@@ -59,7 +59,7 @@
   "problem-immigration-status": {
     "required": "Enter what is wrong with your status"
   },
-  "correct-date-valid-from": {
+  "correct-valid-from-date": {
     "required": "Enter the date your visa is valid from",
     "date": "Enter a real date"
   },

--- a/apps/eec/translations/src/en/validation.json
+++ b/apps/eec/translations/src/en/validation.json
@@ -59,7 +59,7 @@
   "problem-immigration-status": {
     "required": "Enter what is wrong with your status"
   },
-  "correct-visa-date-from": {
+  "correct-visa-start-date": {
     "required": "Enter the date your visa is valid from",
     "date": "Enter a real date"
   },

--- a/apps/eec/translations/src/en/validation.json
+++ b/apps/eec/translations/src/en/validation.json
@@ -59,6 +59,10 @@
   "problem-immigration-status": {
     "required": "Enter what is wrong with your status"
   },
+  "correct-date-valid-from": {
+    "required": "Enter the date your visa is valid from",
+    "date": "Enter a real date"
+  },
   "correct-national-insurance-number": {
     "required": "Enter your National Insurance number",
     "regex" : "Enter a National Insurance number in the correct format"
@@ -125,9 +129,6 @@
   "detail-share-code": {
     "required": "Enter which share code you are unable to create",
     "maxlength": "Enter details that are 200 characters or less"
-  },
-  "detail-valid-from": {
-    "required": "Enter the correct valid from date"
   },
   "detail-valid-until": {
     "required": "Enter the correct valid to date"

--- a/apps/eec/translations/src/en/validation.json
+++ b/apps/eec/translations/src/en/validation.json
@@ -59,7 +59,7 @@
   "problem-immigration-status": {
     "required": "Enter what is wrong with your status"
   },
-  "correct-valid-from-date": {
+  "correct-valid-from": {
     "required": "Enter the date your visa is valid from",
     "date": "Enter a real date"
   },

--- a/apps/eec/translations/src/en/validation.json
+++ b/apps/eec/translations/src/en/validation.json
@@ -59,7 +59,7 @@
   "problem-immigration-status": {
     "required": "Enter what is wrong with your status"
   },
-  "correct-valid-from": {
+  "correct-visa-date": {
     "required": "Enter the date your visa is valid from",
     "date": "Enter a real date"
   },

--- a/apps/eec/translations/src/en/validation.json
+++ b/apps/eec/translations/src/en/validation.json
@@ -59,7 +59,7 @@
   "problem-immigration-status": {
     "required": "Enter what is wrong with your status"
   },
-  "correct-visa-date": {
+  "correct-visa-date-from": {
     "required": "Enter the date your visa is valid from",
     "date": "Enter a real date"
   },


### PR DESCRIPTION
## What?
Added a new page to enable users to enter correct date of their visa is valid from.
Previously, this was handled by toggling the input box behaviour on the problem page; I’ve now removed all of that legacy code.
Implemented conditional routing to navigate testers to the new page (this will be updated later as part of ticket EEC-149).

Current focus: the new page, validations, and the CYA page.

There was an issue(Naxsi error) with the Nginx for the word **from** with date field. Please see details below in **Anything Else** section.

## Why?
EEC-166
## How?

## Testing?

## Screenshots (optional)

With required validation

<img width="667" height="696" alt="image" src="https://github.com/user-attachments/assets/39c0d539-cc39-4e26-8d28-bf27f1ab3ee4" />

With date validation

<img width="633" height="503" alt="image" src="https://github.com/user-attachments/assets/bb77576f-7442-4908-a3e5-971fcc457776" />


CYA page

<img width="682" height="71" alt="image" src="https://github.com/user-attachments/assets/9e7ef154-27e2-439d-8011-1cac070742ce" />


## Anything Else? (optional)

Nginx has issues(Naxsi error) with the word '**from**' with date field. So can't use field name as **correct-date-valid-from**. Because of this I decided to use '**correct-visa-start-date**' as field name.

<img width="1624" height="567" alt="image" src="https://github.com/user-attachments/assets/08aaa7d9-7c57-46b8-9588-6e82bafb45fe" />

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
