### PR TITLE
EEC-169: Add page to enter correct date of visa is valid to.

### DIFF
--- a/apps/eec/fields/index.js
+++ b/apps/eec/fields/index.js
@@ -180,9 +180,7 @@ module.exports = {
         value: 'problem-valid-from'
       },
       {
-        value: 'problem-valid-until',
-        toggle: 'detail-valid-until',
-        child: 'input-text'
+        value: 'problem-valid-to'
       },
       {
         value: 'problem-national-insurance-number'
@@ -255,6 +253,14 @@ module.exports = {
     validate: 'required'
   },
   'correct-visa-start-date': dateComponent('correct-visa-start-date', {
+    isPageHeading: 'true',
+    mixin: 'input-date',
+    validate: [
+      'required',
+      'date'
+    ]
+  }),
+  'correct-visa-end-date': dateComponent('correct-visa-end-date', {
     isPageHeading: 'true',
     mixin: 'input-date',
     validate: [
@@ -340,15 +346,6 @@ module.exports = {
   'detail-share-code': {
     isPageHeading: 'true',
     validate: ['required', { type: 'maxlength', arguments: 200 }]
-  },
-  'detail-valid-until': {
-    mixin: 'input-text',
-    validate: 'required',
-    className: ['govuk-input', 'govuk-!-width-one-third'],
-    dependent: {
-      field: 'problem',
-      value: 'problem-valid-until'
-    }
   },
   'detail-signin-email': {
     mixin: 'input-text',

--- a/apps/eec/index.js
+++ b/apps/eec/index.js
@@ -123,7 +123,6 @@ module.exports = {
       next: '/personal-details',
       fields: [
         'problem',
-        'detail-valid-until',
         'detail-signin-email',
         'detail-signin-phone',
         'detail-other'
@@ -158,6 +157,11 @@ module.exports = {
           target: '/date-valid-from',
           condition: req => req.sessionModel.get('problem') &&
           req.sessionModel.get('problem').includes('problem-valid-from')
+        },
+        {
+          target: '/date-valid-to',
+          condition: req => req.sessionModel.get('problem') &&
+          req.sessionModel.get('problem').includes('problem-valid-to')
         },
         {
           target: '/national-insurance-number',
@@ -234,6 +238,11 @@ module.exports = {
     '/date-valid-from': {
       next: '/personal-details',
       fields: ['correct-visa-start-date'],
+      showNeedHelp: true
+    },
+    '/date-valid-to': {
+      next: '/personal-details',
+      fields: ['correct-visa-end-date'],
       showNeedHelp: true
     },
     '/national-insurance-number': {

--- a/apps/eec/sections/summary-data-sections.js
+++ b/apps/eec/sections/summary-data-sections.js
@@ -61,8 +61,9 @@ module.exports = {
         parse: val => !val ? '' : formatDate(val)
       },
       {
-        step: '/problem',
-        field: 'detail-valid-until'
+        step: '/date-valid-to',
+        field: 'correct-visa-end-date',
+        parse: val => !val ? '' : formatDate(val)
       },
       {
         step: '/national-insurance-number',

--- a/apps/eec/translations/src/en/fields.json
+++ b/apps/eec/translations/src/en/fields.json
@@ -99,6 +99,9 @@
       "problem-valid-from": {
         "label": "Valid from"
       },
+      "problem-valid-to": {
+        "label": "Valid to"
+      },
       "problem-national-insurance-number": {
         "label": "National Insurance number"
       },
@@ -125,9 +128,6 @@
       },
       "problem-status": {
         "label": "Status"
-      },
-      "problem-valid-until": {
-        "label": "Valid to"
       },
       "problem-signin-email": {
         "label": "Email address to sign in to your account"
@@ -165,6 +165,10 @@
   },
   "correct-visa-start-date": {
     "legend": "What is the correct date your visa is valid from?",
+    "hint": "Enter date in the format DD MM YYYY"
+  },
+  "correct-visa-end-date": {
+    "legend": "What is the correct date your visa is valid to?",
     "hint": "Enter date in the format DD MM YYYY"
   },
   "correct-national-insurance-number": {
@@ -229,9 +233,6 @@
   "detail-share-code": {
     "label": "Which share code are you unable to create?",
     "hint": "This could be for right to work, right to rent or something else"
-  },
-  "detail-valid-until": {
-    "label": "What is the correct date your visa is valid to?"
   },
   "detail-signin-email": {
     "label": "What is the correct email address where you can receive security codes?"

--- a/apps/eec/translations/src/en/pages.json
+++ b/apps/eec/translations/src/en/pages.json
@@ -149,6 +149,9 @@
       "correct-visa-start-date": {
         "label": "Valid from"
       },
+      "correct-visa-end-date": {
+        "label": "Valid to"
+      },
       "correct-national-insurance-number": {
         "label": "National Insurance number"
       },
@@ -181,9 +184,6 @@
       },
       "detail-share-code": {
         "label": "Share code"
-      },
-      "detail-valid-until": {
-        "label": "Valid to"
       },
       "detail-signin-email": {
         "label": "Account email"

--- a/apps/eec/translations/src/en/validation.json
+++ b/apps/eec/translations/src/en/validation.json
@@ -63,6 +63,10 @@
     "required": "Enter the date your visa is valid from",
     "date": "Enter a real date"
   },
+  "correct-visa-end-date": {
+    "required": "Enter the date your visa is valid to",
+    "date": "Enter a real date"
+  },
   "correct-national-insurance-number": {
     "required": "Enter your National Insurance number",
     "regex" : "Enter a National Insurance number in the correct format"
@@ -129,9 +133,6 @@
   "detail-share-code": {
     "required": "Enter which share code you are unable to create",
     "maxlength": "Enter details that are 200 characters or less"
-  },
-  "detail-valid-until": {
-    "required": "Enter the correct valid to date"
   },
   "detail-signin-email": {
     "required": "Enter the correct email address where you can receive security codes",


### PR DESCRIPTION
## What?
Added a new page to enable users to enter correct date of their visa is valid to.
Previously, this was handled by toggling the input box behaviour on the problem page; I’ve now removed all of that legacy code.
Implemented conditional routing to navigate testers to the new page (this will be updated later as part of ticket EEC-149).

Current focus: the new page, validations, and the CYA page.

I made field name as correct-visa-end-date for valid-to for consistency, because for valid-from page I had to make as correct-visa-start-date due to Naxsi error with the word from. 

## Why?

EEC-169
## How?

## Testing?

## Screenshots (optional)

With required validation

<img width="645" height="699" alt="image" src="https://github.com/user-attachments/assets/028eb059-af24-4228-8958-3ece5094775b" />

With Invalid date validation

<img width="676" height="520" alt="image" src="https://github.com/user-attachments/assets/b17e5c67-66d6-4b3a-b9e3-7f4d2a95b2df" />

CYA page

<img width="619" height="65" alt="image" src="https://github.com/user-attachments/assets/151bf86c-43a6-4a85-9343-c57b9ac5b59d" />


## Anything Else? (optional)

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
