### PR TITLE
EEC-156: Add page to enter correct email address to signin

### DIFF
--- a/apps/eec/fields/index.js
+++ b/apps/eec/fields/index.js
@@ -210,9 +210,7 @@ module.exports = {
         value: 'problem-share-code'
       },
       {
-        value: 'problem-signin-email',
-        toggle: 'detail-signin-email',
-        child: 'input-text'
+        value: 'problem-signin-email'
       },
       {
         value: 'problem-signin-phone',
@@ -347,18 +345,14 @@ module.exports = {
     isPageHeading: 'true',
     validate: ['required', { type: 'maxlength', arguments: 200 }]
   },
-  'detail-signin-email': {
-    mixin: 'input-text',
+  'correct-signin-email': {
+    isPageHeading: 'true',
     validate: [
       'required',
       'email',
-      { type: 'maxlength', arguments: 254 }
-    ],
-    className: ['govuk-input', 'govuk-!-width-two-thirds'],
-    dependent: {
-      field: 'problem',
-      value: 'problem-signin-email'
-    }
+      { type: 'maxlength', arguments: 254 },
+      { type: 'minlength', arguments: 6 }
+    ]
   },
   'detail-signin-phone': {
     mixin: 'input-text',

--- a/apps/eec/index.js
+++ b/apps/eec/index.js
@@ -123,7 +123,6 @@ module.exports = {
       next: '/personal-details',
       fields: [
         'problem',
-        'detail-signin-email',
         'detail-signin-phone',
         'detail-other'
       ],
@@ -207,6 +206,11 @@ module.exports = {
           target: '/share-code',
           condition: req => req.sessionModel.get('problem') &&
           req.sessionModel.get('problem').includes('problem-share-code')
+        },
+        {
+          target: '/correct-email-address',
+          condition: req => req.sessionModel.get('problem') &&
+          req.sessionModel.get('problem').includes('problem-signin-email')
         }
       ],
       showNeedHelp: true
@@ -330,6 +334,11 @@ module.exports = {
     '/share-code': {
       next: '/personal-details',
       fields: ['detail-share-code'],
+      showNeedHelp: true
+    },
+    '/correct-email-address': {
+      next: '/personal-details',
+      fields: ['correct-signin-email'],
       showNeedHelp: true
     },
     '/personal-details': {

--- a/apps/eec/sections/summary-data-sections.js
+++ b/apps/eec/sections/summary-data-sections.js
@@ -151,8 +151,8 @@ module.exports = {
         field: 'detail-share-code'
       },
       {
-        step: '/problem',
-        field: 'detail-signin-email'
+        step: '/correct-email-address',
+        field: 'correct-signin-email'
       },
       {
         step: '/problem',

--- a/apps/eec/translations/src/en/fields.json
+++ b/apps/eec/translations/src/en/fields.json
@@ -234,8 +234,9 @@
     "label": "Which share code are you unable to create?",
     "hint": "This could be for right to work, right to rent or something else"
   },
-  "detail-signin-email": {
-    "label": "What is the correct email address where you can receive security codes?"
+  "correct-signin-email": {
+    "label": "What is the correct email address to sign in to your account?",
+    "hint": "You will also get security codes sent to this email address"
   },
   "detail-signin-phone": {
     "label": "What is the correct phone number where you can receive security codes?"

--- a/apps/eec/translations/src/en/pages.json
+++ b/apps/eec/translations/src/en/pages.json
@@ -185,8 +185,8 @@
       "detail-share-code": {
         "label": "Share code"
       },
-      "detail-signin-email": {
-        "label": "Account email"
+      "correct-signin-email": {
+        "label": "Email address to sign in to your account"
       },
       "detail-signin-phone": {
         "label": "Account phone"

--- a/apps/eec/translations/src/en/validation.json
+++ b/apps/eec/translations/src/en/validation.json
@@ -134,10 +134,11 @@
     "required": "Enter which share code you are unable to create",
     "maxlength": "Enter details that are 200 characters or less"
   },
-  "detail-signin-email": {
+  "correct-signin-email": {
     "required": "Enter the correct email address where you can receive security codes",
     "email": "Enter an email address in the correct format, like name@example.com",
-    "maxlength": "Email address must be less than 254 characters"
+    "maxlength": "Email address must be between 6 and 254 characters",
+    "minlength": "Email address must be between 6 and 254 characters"
   },
   "detail-signin-phone": {
     "required": "Enter the correct phone number where you can receive security codes",


### PR DESCRIPTION
## What?
Added a new page to enable users to enter correct email address to sign in to their account.
Previously, this was handled by toggling the input box behaviour on the problem page; I’ve now removed all of that legacy code.
Implemented conditional routing to navigate testers to the new page (this will be updated later as part of ticket EEC-149).

Current focus: the new page, validations, and the CYA page.

## Why?

EEC-156

## How?

## Testing?

## Screenshots (optional)

With required validation

<img width="784" height="800" alt="image" src="https://github.com/user-attachments/assets/a7151824-613a-4007-af76-6c71074459d8" />

With email validation

<img width="728" height="563" alt="image" src="https://github.com/user-attachments/assets/d66358b6-9147-4cfb-8241-61053e528f3d" />

With Maxlength validation

<img width="759" height="514" alt="image" src="https://github.com/user-attachments/assets/3e04158b-61ba-4fc4-a65f-425eff2f6a6d" />

Minlength validation I tested locally by increasing the  min number because email format framework validation doesn't allow < 6 for the example a@b.c, so this also goes under email validation. But minlength validation code I have added. 

<img width="703" height="555" alt="image" src="https://github.com/user-attachments/assets/38186d50-7aeb-4eb2-bdff-99ce00cdd264" />

CYA page

<img width="718" height="119" alt="image" src="https://github.com/user-attachments/assets/e738fa85-64aa-46e5-9e1a-10918f123f5c" />


## Anything Else? (optional)

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
