### PR TITLE
EEC-158: Add page to enter the details of not listed problems.

### DIFF
--- a/apps/eec/fields/index.js
+++ b/apps/eec/fields/index.js
@@ -218,9 +218,7 @@ module.exports = {
         child: 'input-text'
       },
       {
-        value: 'problem-other',
-        toggle: 'detail-other',
-        child: 'textarea'
+        value: 'problem-other'
       }
     ]
   },
@@ -363,14 +361,10 @@ module.exports = {
       value: 'problem-signin-phone'
     }
   },
-  'detail-other': {
+  'problem-not-listed': {
     mixin: 'textarea',
     validate: ['required', { type: 'maxlength', arguments: 500 }],
-    attributes: [{ attribute: 'rows', value: 5 }],
-    dependent: {
-      field: 'problem',
-      value: 'problem-other'
-    }
+    attributes: [{ attribute: 'rows', value: 5 }]
   },
   'is-refugee': {
     isPageHeading: 'true',

--- a/apps/eec/index.js
+++ b/apps/eec/index.js
@@ -123,8 +123,7 @@ module.exports = {
       next: '/personal-details',
       fields: [
         'problem',
-        'detail-signin-phone',
-        'detail-other'
+        'detail-signin-phone'
       ],
       forks: [
         {
@@ -211,6 +210,11 @@ module.exports = {
           target: '/correct-email-address',
           condition: req => req.sessionModel.get('problem') &&
           req.sessionModel.get('problem').includes('problem-signin-email')
+        },
+        {
+          target: '/problem-not-listed',
+          condition: req => req.sessionModel.get('problem') &&
+          req.sessionModel.get('problem').includes('problem-other')
         }
       ],
       showNeedHelp: true
@@ -339,6 +343,11 @@ module.exports = {
     '/correct-email-address': {
       next: '/personal-details',
       fields: ['correct-signin-email'],
+      showNeedHelp: true
+    },
+    '/problem-not-listed': {
+      next: '/personal-details',
+      fields: ['problem-not-listed'],
       showNeedHelp: true
     },
     '/personal-details': {

--- a/apps/eec/sections/summary-data-sections.js
+++ b/apps/eec/sections/summary-data-sections.js
@@ -159,8 +159,8 @@ module.exports = {
         field: 'detail-signin-phone'
       },
       {
-        step: '/problem',
-        field: 'detail-other'
+        step: '/problem-not-listed',
+        field: 'problem-not-listed'
       }
     ]
   },

--- a/apps/eec/translations/src/en/fields.json
+++ b/apps/eec/translations/src/en/fields.json
@@ -139,7 +139,7 @@
         "label": "Sponsor licence number"
       },
       "problem-other": {
-        "label": "My problem isn't listed"
+        "label": "My problem is not listed"
       }
   }
   },
@@ -241,7 +241,7 @@
   "detail-signin-phone": {
     "label": "What is the correct phone number where you can receive security codes?"
   },
-  "detail-other": {
+  "problem-not-listed": {
     "label": "Describe the problem you are having"
   },
   "is-refugee": {

--- a/apps/eec/translations/src/en/pages.json
+++ b/apps/eec/translations/src/en/pages.json
@@ -64,6 +64,9 @@
     "header": "What are the correct passport numbers of the adults approved to accompany a child?",
     "intro": "You must enter the same details that you used in your visa application."
   },
+  "problem-not-listed": {
+    "header": "My problem is not listed"
+  },
   "personal-details": {
     "header": "Personal details",
     "intro": "You must enter these details exactly as they appear on your eVisa so we can review the problem."
@@ -191,8 +194,8 @@
       "detail-signin-phone": {
         "label": "Account phone"
       },
-      "detail-other": {
-        "label": "My problem isn't listed"
+      "problem-not-listed": {
+        "label": "My problem is not listed"
       },
       "requestor-full-name": {
         "label": "Full name"

--- a/apps/eec/translations/src/en/validation.json
+++ b/apps/eec/translations/src/en/validation.json
@@ -145,9 +145,9 @@
     "internationalPhoneNumber": "Enter a phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192",
     "regex": "Enter a phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192"
   },
-  "detail-other": {
-    "required": "Enter the problem that isn't listed",
-    "maxlength": "You have exceeded the 500 character limit"
+  "problem-not-listed": {
+    "required": "Enter the problem you are having",
+    "maxlength": "Description must be 500 characters or less"
   },
   "is-refugee": {
     "required": "Select if you have permission to stay in the UK as a refugee"


### PR DESCRIPTION
## What?
Added a new page to enable users to enter the details of not listed problems.
Previously, this was handled by toggling the input box behaviour on the problem page; I’ve now removed all of that legacy code.
Implemented conditional routing to navigate testers to the new page (this will be updated later as part of ticket EEC-149).

Current focus: the new page, validations, and the CYA page.
## Why?
EEC-158
## How?

## Testing?

## Screenshots (optional)

With required validation

<img width="672" height="734" alt="image" src="https://github.com/user-attachments/assets/1f3a5a6f-dc73-4a17-908f-64932c69d85f" />


With Maxlength validation

<img width="629" height="485" alt="image" src="https://github.com/user-attachments/assets/7ddca0c0-4b81-4308-9692-8722da65939a" />

CYA page

<img width="622" height="91" alt="image" src="https://github.com/user-attachments/assets/3b732ac0-9809-4840-8bbe-d198c88b5705" />

## Anything Else? (optional)

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
