### PR TITLE
EEC-157: Add page to enter correct Phone number to sign in. 

### DIFF
--- a/apps/eec/fields/index.js
+++ b/apps/eec/fields/index.js
@@ -213,9 +213,7 @@ module.exports = {
         value: 'problem-signin-email'
       },
       {
-        value: 'problem-signin-phone',
-        toggle: 'detail-signin-phone',
-        child: 'input-text'
+        value: 'problem-signin-phone'
       },
       {
         value: 'problem-other'
@@ -352,14 +350,15 @@ module.exports = {
       { type: 'minlength', arguments: 6 }
     ]
   },
-  'detail-signin-phone': {
-    mixin: 'input-text',
-    className: ['govuk-input', 'govuk-!-width-one-third'],
-    validate: ['required', 'internationalPhoneNumber', startsWithDigitOrPlus],
-    dependent: {
-      field: 'problem',
-      value: 'problem-signin-phone'
-    }
+  'correct-signin-phone': {
+    isPageHeading: 'true',
+    validate: [
+      'required',
+      'internationalPhoneNumber',
+      startsWithDigitOrPlus,
+      { type: 'maxlength', arguments: 30 },
+      { type: 'minlength', arguments: 6 }
+    ]
   },
   'problem-not-listed': {
     mixin: 'textarea',

--- a/apps/eec/fields/index.js
+++ b/apps/eec/fields/index.js
@@ -354,10 +354,10 @@ module.exports = {
     isPageHeading: 'true',
     validate: [
       'required',
-      'internationalPhoneNumber',
-      startsWithDigitOrPlus,
       { type: 'maxlength', arguments: 30 },
-      { type: 'minlength', arguments: 6 }
+      { type: 'minlength', arguments: 6 },
+      'internationalPhoneNumber',
+      startsWithDigitOrPlus
     ]
   },
   'problem-not-listed': {

--- a/apps/eec/index.js
+++ b/apps/eec/index.js
@@ -122,8 +122,7 @@ module.exports = {
     '/problem': {
       next: '/personal-details',
       fields: [
-        'problem',
-        'detail-signin-phone'
+        'problem'
       ],
       forks: [
         {
@@ -210,6 +209,11 @@ module.exports = {
           target: '/correct-email-address',
           condition: req => req.sessionModel.get('problem') &&
           req.sessionModel.get('problem').includes('problem-signin-email')
+        },
+        {
+          target: '/correct-phone-number',
+          condition: req => req.sessionModel.get('problem') &&
+          req.sessionModel.get('problem').includes('problem-signin-phone')
         },
         {
           target: '/problem-not-listed',
@@ -343,6 +347,11 @@ module.exports = {
     '/correct-email-address': {
       next: '/personal-details',
       fields: ['correct-signin-email'],
+      showNeedHelp: true
+    },
+    '/correct-phone-number': {
+      next: '/personal-details',
+      fields: ['correct-signin-phone'],
       showNeedHelp: true
     },
     '/problem-not-listed': {

--- a/apps/eec/sections/summary-data-sections.js
+++ b/apps/eec/sections/summary-data-sections.js
@@ -155,8 +155,8 @@ module.exports = {
         field: 'correct-signin-email'
       },
       {
-        step: '/problem',
-        field: 'detail-signin-phone'
+        step: '/correct-phone-number',
+        field: 'correct-signin-phone'
       },
       {
         step: '/problem-not-listed',

--- a/apps/eec/translations/src/en/fields.json
+++ b/apps/eec/translations/src/en/fields.json
@@ -238,8 +238,9 @@
     "label": "What is the correct email address to sign in to your account?",
     "hint": "You will also get security codes sent to this email address"
   },
-  "detail-signin-phone": {
-    "label": "What is the correct phone number where you can receive security codes?"
+  "correct-signin-phone": {
+    "label": "What is the correct phone number where you can receive security codes?",
+    "hint": " For international numbers, include the country code"
   },
   "problem-not-listed": {
     "label": "Describe the problem you are having"

--- a/apps/eec/translations/src/en/pages.json
+++ b/apps/eec/translations/src/en/pages.json
@@ -191,8 +191,8 @@
       "correct-signin-email": {
         "label": "Email address to sign in to your account"
       },
-      "detail-signin-phone": {
-        "label": "Account phone"
+      "correct-signin-phone": {
+        "label": "Phone number to sign in to your account"
       },
       "problem-not-listed": {
         "label": "My problem is not listed"

--- a/apps/eec/translations/src/en/pages.json
+++ b/apps/eec/translations/src/en/pages.json
@@ -64,6 +64,9 @@
     "header": "What are the correct passport numbers of the adults approved to accompany a child?",
     "intro": "You must enter the same details that you used in your visa application."
   },
+  "correct-phone-number": {
+    "title": "What is the correct phone number?"
+  },
   "problem-not-listed": {
     "header": "My problem is not listed"
   },

--- a/apps/eec/translations/src/en/validation.json
+++ b/apps/eec/translations/src/en/validation.json
@@ -140,10 +140,12 @@
     "maxlength": "Email address must be between 6 and 254 characters",
     "minlength": "Email address must be between 6 and 254 characters"
   },
-  "detail-signin-phone": {
-    "required": "Enter the correct phone number where you can receive security codes",
+  "correct-signin-phone": {
+    "required": "Enter a phone number",
     "internationalPhoneNumber": "Enter a phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192",
-    "regex": "Enter a phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192"
+    "regex": "Enter a phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192",
+    "maxlength": "Phone number must be between 6 and 30 digits",
+    "minlength": "Phone number must be between 6 and 30 digits"
   },
   "problem-not-listed": {
     "required": "Enter the problem you are having",


### PR DESCRIPTION
## What?
Added a new page to enable users to enter correct phone number where they can receive security codes.
Previously, this was handled by toggling the input box behaviour on the problem page; I’ve now removed all of that legacy code.
Implemented conditional routing to navigate testers to the new page (this will be updated later as part of ticket EEC-149).

Current focus: the new page, validations, and the CYA page.

Validation have to revisit.
## Why?

EEC-157

## How?

## Testing?

## Screenshots (optional)

With required validation

<img width="743" height="799" alt="image" src="https://github.com/user-attachments/assets/876acce3-d1ed-40b3-abcb-3cd4b2304af5" />

With minlegth validation

<img width="706" height="553" alt="image" src="https://github.com/user-attachments/assets/c81c68e4-db39-46ab-b639-bd014df16941" />

With maxlength validation

<img width="703" height="545" alt="image" src="https://github.com/user-attachments/assets/d58c4427-a8dc-4cca-901c-4468880dfd7a" />

With International Phone number validation
<img width="705" height="593" alt="image" src="https://github.com/user-attachments/assets/3aebc11c-bf5a-4ce7-9145-cb76b66d1a0e" />

CYA page

<img width="674" height="104" alt="image" src="https://github.com/user-attachments/assets/28dd8555-29eb-4310-8c8e-01a9a11da8d2" />


## Anything Else? (optional)

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
