### PR TITLE
EEC-184: Fix page title for correct email address page.

### DIFF
--- a/apps/eec/translations/src/en/pages.json
+++ b/apps/eec/translations/src/en/pages.json
@@ -64,6 +64,9 @@
     "header": "What are the correct passport numbers of the adults approved to accompany a child?",
     "intro": "You must enter the same details that you used in your visa application."
   },
+  "correct-email-address": {
+    "title": "What is the correct email address?"
+  },
   "correct-phone-number": {
     "title": "What is the correct phone number?"
   },


### PR DESCRIPTION
## What?
There is different title for the page correct-email-address. Which is missed with the main ticket .
## Why?

## How?

## Testing?

## Screenshots (optional)

## Anything Else? (optional)

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
