### PR TITLE
EEC-160: Change url, contents and button text in CYA page.

### DIFF
--- a/apps/eec/index.js
+++ b/apps/eec/index.js
@@ -16,7 +16,7 @@ module.exports = {
   name: 'eec',
   baseUrl: '/',
   params: '/:action?/:id?/:edit?',
-  confirmStep: '/check-answers',
+  confirmStep: '/check-your-answers',
   steps: {
     '/in-uk': {
       next: '/accessing-evisa',
@@ -408,7 +408,7 @@ module.exports = {
       showNeedHelp: true
     },
     '/someone-else': {
-      next: '/check-answers',
+      next: '/check-your-answers',
       fields: ['completing-for-someone-else'],
       forks: [
         {
@@ -422,7 +422,7 @@ module.exports = {
       showNeedHelp: true
     },
     '/someone-else-details': {
-      next: '/check-answers',
+      next: '/check-your-answers',
       fields: [
         'representative-name',
         'representative-email',
@@ -430,7 +430,7 @@ module.exports = {
       ],
       showNeedHelp: true
     },
-    '/check-answers': {
+    '/check-your-answers': {
       behaviours: [Summary, submitRequest],
       sections: require('./sections/summary-data-sections'),
       template: 'summary',

--- a/apps/eec/translations/src/en/buttons.json
+++ b/apps/eec/translations/src/en/buttons.json
@@ -1,7 +1,7 @@
 {
   "edit": "Change",
   "continue": "Continue",
-  "submit": "Submit request",
+  "submit": "Accept and send",
   "finish-and-return": "Finish and return to GOV.UK",
   "continue-to-report-an-error": "Continue to report an error"
 }

--- a/apps/eec/translations/src/en/pages.json
+++ b/apps/eec/translations/src/en/pages.json
@@ -84,7 +84,8 @@
     "intro": "We will attempt to contact the requestor directly. We will only use these details to contact you if needed.",
     "consent": "By continuing, you confirm that you have consent to send this request on their behalf."
   },
-  "check-answers": {
+  "check-your-answers": {
+    "title": "Check your answers",
     "header": "Check your answers before sending your request",
     "send-request": {
       "header": "Send your request",
@@ -105,7 +106,7 @@
         "header": "Travel details"
       },
       "corrected-details": {
-        "header": "eVisa details to be corrected to"
+        "header": "eVisa details to be corrected"
       },
       "your-evisa-details": {
         "header": "Your current eVisa details"

--- a/apps/eec/views/summary.html
+++ b/apps/eec/views/summary.html
@@ -5,11 +5,11 @@
         {{> partials-summary-table}}
       {{/rows}}
     </div>
-    <h2 class="govuk-heading-m">{{#t}}pages.check-answers.send-request.header{{/t}}</h2>
-    <p class="govuk-body">{{#t}}pages.check-answers.send-request.disclaimer{{/t}}</p>
+    <h2 class="govuk-heading-m">{{#t}}pages.check-your-answers.send-request.header{{/t}}</h2>
+    <p class="govuk-body">{{#t}}pages.check-your-answers.send-request.disclaimer{{/t}}</p>
     <p class="govuk-body">
-      {{#t}}pages.check-answers.send-request.link-intro{{/t}}
-      <a href="https://www.gov.uk/government/publications/personal-information-use-in-borders-immigration-and-citizenship/borders-immigration-and-citizenship-privacy-information-notice" class="govuk-link">{{#t}}pages.check-answers.send-request.link-text{{/t}}</a>.
+      {{#t}}pages.check-your-answers.send-request.link-intro{{/t}}
+      <a href="https://www.gov.uk/government/publications/personal-information-use-in-borders-immigration-and-citizenship/borders-immigration-and-citizenship-privacy-information-notice" class="govuk-link">{{#t}}pages.check-your-answers.send-request.link-text{{/t}}</a>.
     </p>
     {{#input-submit}}submit{{/input-submit}}
   {{/page-content}}


### PR DESCRIPTION
## What?

Changed url, headers, title and button text in check your answers (CYA) page.
Other all page related content display have been done as part of relevant page tickets.

## Why?
EEC-160
## How?

## Testing?

## Screenshots (optional)

<img width="467" height="715" alt="image" src="https://github.com/user-attachments/assets/86037278-959c-4ca5-bf52-a87ee2f07f8e" />


## Anything Else? (optional)

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
