### PR TITLE
feat(e2e): initial Playwright migration for EEC with UI-copy alignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ test/_accessibility/tmp/*
 .npm
 .yarn
 .yarnrc
+.features-gen
+playwright-report
+test-results

--- a/apps/eec/behaviours/submit-request.js
+++ b/apps/eec/behaviours/submit-request.js
@@ -9,7 +9,8 @@ const {
 const { getLabel, formatDate, genNotifyErrorMsg } = require('../../../utils');
 
 const NotifyClient = require('notifications-node-client').NotifyClient;
-const Notify = new NotifyClient(notifyApiKey);
+const useMockNotify = process.env.E2E_MOCK_NOTIFY === 'true';
+const Notify = useMockNotify || !notifyApiKey ? null : new NotifyClient(notifyApiKey);
 
 class EmailProps {
   constructor() {
@@ -50,6 +51,11 @@ module.exports = superclass => class extends superclass {
     const businessEmailProps = new EmailProps;
 
     try {
+      if (useMockNotify) {
+        req.log('info', 'EEC mock notify enabled - skipping caseworker email send');
+        return super.saveValues(req, res, next);
+      }
+
       businessEmailProps.addPersonalisation({
         in_uk: getLabel('in-uk', req.sessionModel.get('in-uk')),
         is_not_in_uk: req.sessionModel.get('in-uk') === 'no' ? 'yes' : 'no',

--- a/e2e-tests/features/eec/eecE2e.feature
+++ b/e2e-tests/features/eec/eecE2e.feature
@@ -1,0 +1,36 @@
+@EecRegression1
+@regression1 @RegressionTestCI
+#Feature: EEC - E-Visa Error Correction Service Form
+#https://collaboration.homeoffice.gov.uk/jira/browse/EEC-1
+
+Feature: EEC - E-Visa Error Correction Service Form
+  @EEC-E2E
+  Scenario Outline: E-Visa Error Correction Service form E2E test
+    Given I visit the E-Visa error correction page
+    When I fill out the answers to EEC form pertaining to "<EEC Journey Test>" happy path test
+    Then I should see "Request sent" page for EEC
+    And Finish and return to GOV.UK button is displayed for EEC
+    Examples:
+       | EEC Journey Test                                                                                                                                    |
+       | T1: test with view your visa, brp number, email, license and form completed on behalf of someone else                                               |
+       | T2: test with update your account, gwf number, email, license  and form completed on behalf of someone else                                         |
+       | T3: test with report error, uan number, email, license and form completed on behalf of someone else                                                 |
+       | T4: test with cannot access eVisa, passport number, email and form completed on behalf of someone else                                              |
+       | T5: test with view your visa, ukvi customer number, email and form completed by themself                                                            |
+       | T6: test with update your account, i do not have a reference number, uk address and form completed on behalf of someone else                        |
+       | T7: test with view your visa, brp number, email, photo and form completed on behalf of someone else                                                 |
+       | T8: test with view your visa, brp number, email, share code and form completed on behalf of someone else                                            |
+       | T9: test with view your visa, brp number, email, nationality and form completed on behalf of someone else                                           |
+       | T10: test with view your visa, brp number, email, future spouse or civil partner name and form completed on behalf of someone else                  |
+       | T11: test with view your visa, brp number, email, ship and port details and form completed on behalf of someone else                                |
+       | T12: test with view your visa, brp number, email address to sign in to your account and form completed on behalf of someone else                    |
+       | T13: test with view your visa, brp number, phone number to sign in to your account and form completed on behalf of someone else                     |
+       | T14: test with view your visa, brp number, what you can and cannot do in the uk and form completed on behalf of someone else                        |
+       | T15: test with view your visa, brp number, my problem is not listed and form completed on behalf of someone else                                    |
+       | T16: test with view your visa, brp number, valid from and form completed on behalf of someone else                                                  |
+       | T17: test with view your visa, brp number, valid to and form completed on behalf of someone else                                                    |
+       | T18: test with view your visa, brp number, name or passport numbers of accompanying adult and form completed on behalf of someone else              |
+       | T19: test with view your visa, brp number, name or passport numbers of accompanying adult for 2 adults and form completed on behalf of someone else |
+
+
+

--- a/e2e-tests/features/eec/eecValidation.feature
+++ b/e2e-tests/features/eec/eecValidation.feature
@@ -1,0 +1,486 @@
+@EecRegression1
+@EEC-V
+
+Feature: EEC - E-Visa Error Correction Service Form validation test
+#https://collaboration.homeoffice.gov.uk/jira/browse/EEC-1
+
+#Are you currently in the UK
+#Can you access your eVisa?
+#Provide more details about the error with your eVisa
+  Scenario: EEC Test-1 Validate the above pages
+    Given I visit the E-Visa error correction page
+    When I choose to navigate to "Are you currently in the UK" page for EEC
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "Select if you are currently in the UK" error summary
+    When I answer "Yes" on "Are you currently in the UK?" page and choose to continue for EEC
+#Page: Can you access your eVisa?
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "Select yes if you can access your eVisa" error summary
+    When I answer "No, I cannot access my eVisa or UKVI account"
+    And I select continue to report an error
+#Page: Provide more details about the error with your eVisa
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "Enter the error with your eVisa" error summary
+#User enters more than 2000 characters
+    When I enter "2001" characters in the Describe the error field on the "Provide more details about the error with your eVisa" page
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "You have exceeded the 2000 character limit" error summary
+
+
+  @EEC-V2
+# Have you booked your travel to the UK? page
+# Enter your travel document details page
+# Did you pay for a priority or super priority service?
+  Scenario: EEC Test-2 Validate the above pages
+    Given I visit the E-Visa error correction page
+    When I choose to navigate to "Have you booked your travel to the UK?" page for EEC
+#Have you booked your travel to the UK? page
+#No data entered in any of the fields
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "Select if you have booked your travel to the UK" error summary
+#Date validation
+    When I answer "Yes" and "" on "Have you booked your travel to the UK?" page and choose to continue for EEC
+    Then I should see "There is a problem" error message displayed
+    And I should see "Enter the correct date your travel was booked" error summary
+    When I answer "Yes" and "Today's date" on "Have you booked your travel to the UK?" page and choose to continue for EEC
+#Enter your travel document details page
+#No data entered in any of the fields
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "Enter your document number¬Enter your country of nationality¬Enter your date of birth" error summary
+#Document number: Only letters and numbers, no special characters or space and Date of birth: can not be in the past
+    When I complete Enter your travel document details fields with the below details:
+      | Document number        | £12038397A      |
+      | Country of nationality | Aland Islands   |
+      | Date of birth          | Tomorrow's date |
+    Then I should see "There is a problem" error message displayed
+    And I should see "Document number must only include numbers and letters¬Date of birth must be in the past" error summary
+#Date of birth: has special characters
+    When I complete Enter your travel document details fields with the below details:
+      | Document number        | 1             |
+      | Country of nationality | Aland Islands |
+      | Date of birth          | *2/02/2000    |
+    Then I should see "There is a problem" error message displayed
+    And I should see "The date must only contain numbers. For example, 31 3 1980" error summary
+#Date of birth: is 120 years or more in the past
+    When I complete Enter your travel document details fields with the below details:
+      | Document number        | 120383978A              |
+      | Country of nationality | Aland Islands           |
+      | Date of birth          | more than 120 years ago |
+    Then I should see "There is a problem" error message displayed
+    And I should see "Enter a real date of birth" error summary
+    When I complete Enter your travel document details fields with the below details:
+      | Document number        | 120383978A       |
+      | Country of nationality | Aland Islands    |
+      | Date of birth          | Yesterday's date |
+#Did you pay for a priority or super priority service? page
+    Then I should see "Did you pay for a priority or super priority service?" page for EEC
+
+  @EEC-V3
+# What is the problem with your eVisa page
+  Scenario: EEC Test-3 Validate the above pages
+    Given I visit the E-Visa error correction page
+    When I choose to navigate to "What is the problem with your eVisa?" page for EEC
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+#No checkbox selected
+    Then I should see "There is a problem" error message displayed
+    And I should see "Select what the problem is" error summary
+#Name field: no data entered
+    When I select "Name" checkbox and enter "" value in "What is your correct name?" field on What is the problem with your eVisa? page for EEC
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "Enter your correct name" error summary
+    When I select the back button
+    When I deselect "Name" checkbox on What is the problem with your eVisa? page for EEC
+#DOB field: no data entered
+    And I select "Date of birth" checkbox and enter "" value in "What is your correct date of birth?" field on What is the problem with your eVisa? page for EEC
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "Enter your date of birth" error summary
+    When I select the back button
+    When I deselect "Date of birth" checkbox on What is the problem with your eVisa? page for EEC
+#DOB field: Incorrect data entered
+    And I select "Date of birth" checkbox and enter "11/13/1990" value in "What is your correct date of birth?" field on What is the problem with your eVisa? page for EEC
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "The date must only contain numbers. For example, 31 3 1980" error summary
+    When I select the back button
+    When I deselect "Date of birth" checkbox on What is the problem with your eVisa? page for EEC
+#Nationality field: no data entered
+    When I select "Nationality" checkbox and enter "" value in "What is your correct nationality?" field on What is the problem with your eVisa? page for EEC
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "Enter your nationality" error summary
+    When I select the back button
+    When I deselect "Nationality" checkbox on What is the problem with your eVisa? page for EEC
+#Status field: no data entered
+    When I select "Status" checkbox and enter "" value in "What problem are you having with your immigration status?" field on What is the problem with your eVisa? page for EEC
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "Enter what is wrong with your status" error summary
+    When I select the back button
+    When I deselect "Status" checkbox on What is the problem with your eVisa? page for EEC
+#Valid from field: no data entered
+    And I select "Valid from" checkbox and enter "" value in "What is the correct date your visa is valid from?" field on What is the problem with your eVisa? page for EEC
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "Enter the date your visa is valid from" error summary
+    When I select the back button
+    When I deselect "Valid from" checkbox on What is the problem with your eVisa? page for EEC
+#Valid to field: no data entered
+    And I select "Valid to" checkbox and enter "" value in "What is the correct date your visa is valid to?" field on What is the problem with your eVisa? page for EEC
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "Enter the date your visa is valid to" error summary
+    When I select the back button
+    When I deselect "Valid to" checkbox on What is the problem with your eVisa? page for EEC
+#National Insurance number field: no data entered
+    And I select "National Insurance number" checkbox and enter "" value in "What is your correct National Insurance number?" field on What is the problem with your eVisa? page for EEC
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "Enter your National Insurance number" error summary
+    When I select the back button
+    When I deselect "National Insurance number" checkbox on What is the problem with your eVisa? page for EEC
+#Photo text field: no data entered
+    And I select "Photo" checkbox and enter "" value in "What is wrong with your photo?" field on What is the problem with your eVisa? page for EEC
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "Describe the problem you are having" error summary
+    When I select the back button
+    When I deselect "Photo" checkbox on What is the problem with your eVisa? page for EEC
+#What you can and cannot do in the UK field: no data entered
+    And I select "What you can and cannot do in the UK" checkbox and enter "" value in "What is wrong with the details of what you can and cannot do in the UK?" field on What is the problem with your eVisa? page for EEC
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "Enter what is wrong with the details of what you can and cannot do in the UK" error summary
+    When I select the back button
+    When I deselect "What you can and cannot do in the UK" checkbox on What is the problem with your eVisa? page for EEC
+#What you can and cannot do in the UK field: 500 character limit
+    And I select "What you can and cannot do in the UK" checkbox and enter "501" characters in "What is wrong with the details of what you can and cannot do in the UK?" field on What is the problem with your eVisa? page for EEC
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "Enter details that are 500 characters or less" error summary
+    When I select the back button
+    When I deselect "What you can and cannot do in the UK" checkbox on What is the problem with your eVisa? page for EEC
+#Share code field: no data entered
+    And I select "Share code" checkbox and enter "" value in "Which share code are you unable to create?" field on What is the problem with your eVisa? page for EEC
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "Enter which share code you are unable to create" error summary
+    When I select the back button
+    When I deselect "Share code" checkbox on What is the problem with your eVisa? page for EEC
+#Email address to sign in to your account field: no data entered
+    And I select "Email address to sign in to your account" checkbox and enter "" value in "What is the correct email address where you can receive security codes?" field on What is the problem with your eVisa? page for EEC
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "Enter the correct email address where you can receive security codes" error summary
+    When I select the back button
+    When I deselect "Email address to sign in to your account" checkbox on What is the problem with your eVisa? page for EEC
+#Email address to sign in to your account field: email address start with @ symbol
+    And I select "Email address to sign in to your account" checkbox and enter "@Kings.com" value in "What is the correct email address where you can receive security codes?" field on What is the problem with your eVisa? page for EEC
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "Enter an email address in the correct format, like name@example.com" error summary
+    When I select the back button
+    When I deselect "Email address to sign in to your account" checkbox on What is the problem with your eVisa? page for EEC
+#Email address to sign in to your account field: email address end with @ symbol
+    And I select "Email address to sign in to your account" checkbox and enter "Kings.com@" value in "What is the correct email address where you can receive security codes?" field on What is the problem with your eVisa? page for EEC
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "Enter an email address in the correct format, like name@example.com" error summary
+    When I select the back button
+    When I deselect "Email address to sign in to your account" checkbox on What is the problem with your eVisa? page for EEC
+#Email address to sign in to your account field: email address short Contact email address is less than 6 characters
+    And I select "Email address to sign in to your account" checkbox and enter "a@b.c" value in "What is the correct email address where you can receive security codes?" field on What is the problem with your eVisa? page for EEC
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "Enter an email address in the correct format, like name@example.com" error summary
+    When I select the back button
+    When I deselect "Email address to sign in to your account" checkbox on What is the problem with your eVisa? page for EEC
+#Email address to sign in to your account field: email address does not have @ symbol
+    And I select "Email address to sign in to your account" checkbox and enter "TesterTlf.co" value in "What is the correct email address where you can receive security codes?" field on What is the problem with your eVisa? page for EEC
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "Enter an email address in the correct format, like name@example.com" error summary
+    When I select the back button
+    When I deselect "Email address to sign in to your account" checkbox on What is the problem with your eVisa? page for EEC
+#Phone number to sign in to your account field: no data entered
+    And I select "Phone number to sign in to your account" checkbox and enter "" value in "What is the correct phone number where you can receive security codes?" field on What is the problem with your eVisa? page for EEC
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "Enter a phone number" error summary
+    When I select the back button
+    When I deselect "Phone number to sign in to your account" checkbox on What is the problem with your eVisa? page for EEC
+#Phone number to sign in to your account field: more than 12
+    And I select "Phone number to sign in to your account" checkbox and enter "016155010012" value in "What is the correct phone number where you can receive security codes?" field on What is the problem with your eVisa? page for EEC
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "Enter a phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192" error summary
+    When I select the back button
+    When I deselect "Phone number to sign in to your account" checkbox on What is the problem with your eVisa? page for EEC
+#Phone number to sign in to your account field: less than 12
+    And I select "Phone number to sign in to your account" checkbox and enter "+44808157019" value in "What is the correct phone number where you can receive security codes?" field on What is the problem with your eVisa? page for EEC
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "Enter a phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192" error summary
+    When I select the back button
+    When I deselect "Phone number to sign in to your account" checkbox on What is the problem with your eVisa? page for EEC
+#Phone number to sign in to your account field: special character
+    And I select "Phone number to sign in to your account" checkbox and enter "&448081570192" value in "What is the correct phone number where you can receive security codes?" field on What is the problem with your eVisa? page for EEC
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "Enter a phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192" error summary
+    When I select the back button
+    When I deselect "Phone number to sign in to your account" checkbox on What is the problem with your eVisa? page for EEC
+#Phone number to sign in to your account field: Non-numeric
+    And I select "Phone number to sign in to your account" checkbox and enter "abc123456789" value in "What is the correct phone number where you can receive security codes?" field on What is the problem with your eVisa? page for EEC
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "Enter a phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192" error summary
+    When I select the back button
+    When I deselect "Phone number to sign in to your account" checkbox on What is the problem with your eVisa? page for EEC
+
+#Sponsor license number field: no data entered
+    And I select "Sponsor licence number" checkbox and enter "  " value in "What is your correct sponsor licence number?" field on What is the problem with your eVisa? page for EEC
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "Enter your sponsor licence number" error summary
+    When I select the back button
+    When I deselect "Sponsor licence number" checkbox on What is the problem with your eVisa? page for EEC
+#Sponsor license number field: more than 20
+    And I select "Sponsor licence number" checkbox and enter "016155244422220100122" value in "What is your correct sponsor licence number?" field on What is the problem with your eVisa? page for EEC
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "Sponsor licence number must be 20 characters or less" error summary
+    When I select the back button
+    When I deselect "Sponsor licence number" checkbox on What is the problem with your eVisa? page for EEC
+#Sponsor license number field: special character
+    And I select "Sponsor licence number" checkbox and enter "&448081570192" value in "What is your correct sponsor licence number?" field on What is the problem with your eVisa? page for EEC
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "Sponsor licence number can only contain letters a to z or numbers 0 to 9" error summary
+    When I select the back button
+    When I deselect "Sponsor licence number" checkbox on What is the problem with your eVisa? page for EEC
+
+#My problem isn't listed field: no data entered
+    And I select "My problem isn't listed" checkbox and enter "" value in "Describe the problem you are having" field on What is the problem with your eVisa? page for EEC
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "Enter the problem you are having" error summary
+    When I select the back button
+    When I deselect "My problem isn't listed" checkbox on What is the problem with your eVisa? page for EEC
+#My problem isn't listed field: 500 character limit
+    And I select "My problem isn't listed" checkbox and enter "501" characters in "Describe the problem you are having" field on What is the problem with your eVisa? page for EEC
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "Description must be 500 characters or less" error summary
+
+  @EEC-V4
+#Personal details page
+  Scenario: EEC Test-4 Validate the above pages
+    Given I visit the E-Visa error correction page
+    When I choose to navigate to "Personal details" page for EEC
+    And I select continue
+#No data entered in any of the fields
+    Then I should see "There is a problem" error message displayed
+    And I should see "Enter your full name¬Enter your date of birth¬Enter a country of nationality¬Enter a reference number" error summary
+#Full name invalid and 'Date of birth’ in the future and 'Country of nationality’ invalid (value not selected from list)
+    When I complete Personal details fields with the below details:
+      | Full name                     | T3d H0F         |
+      | Date of birth                 | Tomorrow's date |
+      | Country of nationality        | England         |
+      | Radio option                  | BRP number      |
+      | Radio option reference number | RZX123456       |
+    Then I should see "There is a problem" error message displayed
+#    And I should see "Full name must only include letters a to z, spaces, hyphens and apostrophes¬Date of birth must be in the past¬Enter a country of nationality" error summary
+#BRP field empty
+    When I complete Personal details fields with the below details:
+      | Full name                     | Top Hof    |
+      | Date of birth                 | 11/11/1990 |
+      | Country of nationality        | Spain      |
+      | Radio option                  | BRP number |
+      | Radio option reference number |            |
+    Then I should see "There is a problem" error message displayed
+    And I should see "What is your BRP number?" error summary
+#GWF field empty
+    When I complete Personal details fields with the below details:
+      | Full name                     | Top Hof    |
+      | Date of birth                 | 11/11/1990 |
+      | Country of nationality        | Spain      |
+      | Radio option                  | GWF number |
+      | Radio option reference number |            |
+    Then I should see "There is a problem" error message displayed
+    And I should see "What is your GWF number?" error summary
+#UAN field empty
+    When I complete Personal details fields with the below details:
+      | Full name                     | Top Hof    |
+      | Date of birth                 | 11/11/1990 |
+      | Country of nationality        | Spain      |
+      | Radio option                  | UAN number |
+      | Radio option reference number |            |
+    Then I should see "There is a problem" error message displayed
+    And I should see "What is your UAN number?" error summary
+#Passport field empty
+    When I complete Personal details fields with the below details:
+      | Full name                     | Top Hof         |
+      | Date of birth                 | 11/11/1990      |
+      | Country of nationality        | Spain           |
+      | Radio option                  | Passport number |
+      | Radio option reference number |                 |
+    Then I should see "There is a problem" error message displayed
+    And I should see "What is your passport number?" error summary
+#UKVI customer number field empty
+    When I complete Personal details fields with the below details:
+      | Full name                     | Top Hof              |
+      | Date of birth                 | 11/11/1990           |
+      | Country of nationality        | Spain                |
+      | Radio option                  | UKVI customer number |
+      | Radio option reference number |                      |
+    Then I should see "There is a problem" error message displayed
+    And I should see "What is your UKVI customer number?" error summary
+#BRP field is invalid
+    When I complete Personal details fields with the below details:
+      | Full name                     | Top Hof    |
+      | Date of birth                 | 11/11/1990 |
+      | Country of nationality        | Spain      |
+      | Radio option                  | BRP number |
+      | Radio option reference number | Z1234567   |
+    Then I should see "There is a problem" error message displayed
+    And I should see "Enter your BRP number in the correct format; for example RZX123456 or RZ1234567" error summary
+#GWF field is invalid
+    When I complete Personal details fields with the below details:
+      | Full name                     | Top Hof      |
+      | Date of birth                 | 11/11/1990   |
+      | Country of nationality        | Spain        |
+      | Radio option                  | GWF number   |
+      | Radio option reference number | GWD012345678 |
+    Then I should see "There is a problem" error message displayed
+    And I should see "Enter your GWF number in the correct format; for example, GWF012345678" error summary
+#UAN field is invalid
+    When I complete Personal details fields with the below details:
+      | Full name                     | Top Hof            |
+      | Date of birth                 | 11/11/1990         |
+      | Country of nationality        | Spain              |
+      | Radio option                  | UAN number         |
+      | Radio option reference number | 234-1234-1234-1234 |
+    Then I should see "There is a problem" error message displayed
+    And I should see "Enter your UAN in the correct format; for example, 1234-1234-1234-1234" error summary
+#UKVI customer number field is invalid
+    When I complete Personal details fields with the below details:
+      | Full name                     | Top Hof              |
+      | Date of birth                 | 11/11/1990           |
+      | Country of nationality        | Spain                |
+      | Radio option                  | UKVI customer number |
+      | Radio option reference number | KK12345678           |
+    Then I should see "There is a problem" error message displayed
+    And I should see "UKVI customer number must start with KX" error summary
+#UKVI customer number field incorrect length
+    When I complete Personal details fields with the below details:
+      | Full name                     | Top Hof              |
+      | Date of birth                 | 11/11/1990           |
+      | Country of nationality        | Spain                |
+      | Radio option                  | UKVI customer number |
+      | Radio option reference number | KX1234567            |
+    Then I should see "There is a problem" error message displayed
+    And I should see "UKVI customer number must be 10 characters long" error summary
+
+
+#Do you have permission to stay in the UK as a refugee page
+#Do you get asylum support page
+  Scenario: EEC Test-5 Validate the above pages
+    Given I visit the E-Visa error correction page
+    When I choose to navigate to "Do you have permission to stay in the UK as a refugee?" page for EEC
+#Do you have permission to stay in the UK as a refugee page
+#No data entered in any of the fields
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "Select if you have permission to stay in the UK as a refugee" error summary
+    When I answer "Yes" on "Do you have permission to stay in the UK as a refugee?" page and choose to continue for EEC
+#Do you get asylum support page
+#No data entered in any of the fields
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "Select if you are receiving asylum support" error summary
+
+
+
+#How should we contact you about your eVisa page
+  Scenario: EEC Test-6 Validate the above pages
+    Given I visit the E-Visa error correction page
+    When I choose to navigate to "How should we contact you about your eVisa?" page for EEC
+#No data entered in any of the fields
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "Select how you want to be contacted" error summary
+#Email address empty
+    When I complete How should we contact you about your eVisa? via email with the below details:
+      | Radio Option | Email |
+      | Email Value  |       |
+    Then I should see "There is a problem" error message displayed
+    And I should see "Enter an email address" error summary
+#Email address incorrect format
+    When I complete How should we contact you about your eVisa? via email with the below details:
+      | Radio Option | Email     |
+      | Email Value  | @test.com |
+    Then I should see "There is a problem" error message displayed
+    And I should see "Enter an email address in the correct format, like name@example.com" error summary
+#Address line 1, Town or city, and Postcode fields are empty
+    When I complete How should we contact you about your eVisa? via uk address with the below details:
+      | Radio Option   | UK address |
+      | Address line 1 |            |
+      | Address line 2 |            |
+      | Town or City   |            |
+      | Country        |            |
+      | Postcode       |            |
+    Then I should see "There is a problem" error message displayed
+    And I should see "Enter address line 1, typically your building and street¬Enter your town or city¬Enter your postcode" error summary
+#UK address: Postcode incorrect format
+    When I complete How should we contact you about your eVisa? via uk address with the below details:
+      | Radio Option   | UK address |
+      | Address line 1 | 12         |
+      | Address line 2 | Kings      |
+      | Town or City   | Leeds      |
+      | Country        | UK         |
+      | Postcode       | L!2 1PP    |
+    Then I should see "There is a problem" error message displayed
+    And I should see "Enter a valid UK postcode" error summary
+
+
+
+#Are you completing this form on behalf of someone else? page
+#What are your details page
+  Scenario: EEC Test-7 Validate the above pages
+    Given I visit the E-Visa error correction page
+    When I choose to navigate to "Are you completing this form on behalf of someone else?" page for EEC
+#Are you completing this form on behalf of someone else? page: radio option is not selected
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "Select if you are completing this form on behalf of someone else" error summary
+    When I answer "Yes" on Are you completing this form on behalf of someone else? page for EEC and choose to continue
+#What are your details page: Full name, Email address and Type of support fields are empty
+    And I select continue
+    Then I should see "There is a problem" error message displayed
+    And I should see "Enter your full name¬Enter your email address¬Select which type of support you are to the requestor" error summary
+#What are your details page: Full name invalid characters
+    When I complete What are your details fields with the below details:
+      | Radio Option    | Yes            |
+      | Full name       | 1Full name     |
+      | Email address   | Kings@test.com |
+      | Type of support | Sponsor        |
+    Then I should see "There is a problem" error message displayed
+    And I should see "Full name must only include letters a to z, spaces, hyphens and apostrophes" error summary
+#What are your details page: Email address incorrect format
+    When I complete What are your details fields with the below details:
+      | Radio Option    | Yes        |
+      | Full name       | Full name  |
+      | Email address   | @Kings.com |
+      | Type of support | Sponsor    |
+    Then I should see "There is a problem" error message displayed
+    And I should see "Enter an email address in the correct format, like name@example.com" error summary
+

--- a/e2e-tests/playwright.config.ts
+++ b/e2e-tests/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from '@playwright/test';
+import { defineBddConfig } from 'playwright-bdd';
+import dotenv from 'dotenv';
+
+dotenv.config({ quiet: true });
+
+const testDir = defineBddConfig({
+  features: ['features/**/*.feature'],
+  steps: ['steps/**/*.ts'],
+  outputDir: '.features-gen'
+});
+
+export default defineConfig({
+  testDir,
+  testMatch: /.*\.spec\.js/,
+  fullyParallel: false,
+  retries: 0,
+  workers: 1,
+  reporter: [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:8080',
+    screenshot: 'on',
+    video: 'on',
+    trace: 'on-first-retry'
+  }
+});

--- a/e2e-tests/steps/eec.steps.ts
+++ b/e2e-tests/steps/eec.steps.ts
@@ -1,0 +1,819 @@
+import { createBdd, test } from 'playwright-bdd';
+import { expect, Locator, Page } from '@playwright/test';
+import { DataTable } from '@cucumber/cucumber';
+
+const { Given, When, Then } = createBdd(test);
+
+type ProblemLabel =
+  | 'Name'
+  | 'Date of birth'
+  | 'Nationality'
+  | 'Status'
+  | 'Valid from'
+  | 'Valid to'
+  | 'National Insurance number'
+  | 'Photo'
+  | 'What you can and cannot do in the UK'
+  | 'Share code'
+  | 'Email address to sign in to your account'
+  | 'Phone number to sign in to your account'
+  | 'Sponsor licence number'
+  | "My problem isn't listed"
+  | 'Future spouse or civil partner name'
+  | 'Ship and port details'
+  | 'Name or passport numbers of accompanying adult';
+
+function kvTable(dataTable: DataTable): Record<string, string> {
+  const map: Record<string, string> = {};
+  for (const row of dataTable.raw()) {
+    if (row.length >= 2) {
+      map[row[0]] = row[1] ?? '';
+    }
+  }
+  return map;
+}
+
+function addDays(base: Date, days: number): Date {
+  const d = new Date(base);
+  d.setDate(d.getDate() + days);
+  return d;
+}
+
+function addYears(base: Date, years: number): Date {
+  const d = new Date(base);
+  d.setFullYear(d.getFullYear() + years);
+  return d;
+}
+
+function toDmyString(date: Date): string {
+  const d = String(date.getDate());
+  const m = String(date.getMonth() + 1);
+  const y = String(date.getFullYear());
+  return `${d}/${m}/${y}`;
+}
+
+function resolveDateInput(value: string): string {
+  const v = value.trim().toLowerCase();
+  const today = new Date();
+
+  if (v === "today's date") return toDmyString(today);
+  if (v === "tomorrow's date") return toDmyString(addDays(today, 1));
+  if (v === "yesterday's date") return toDmyString(addDays(today, -1));
+  if (v === 'more than 120 years ago') return toDmyString(addYears(today, -121));
+  return value;
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+async function checkRadioByAnswer(page: Page, answer: string): Promise<void> {
+  async function activate(option: Locator): Promise<void> {
+    const alreadyChecked = await option.isChecked().catch(() => false);
+    if (alreadyChecked) return;
+
+    await option.click();
+
+    const nowChecked = await option.isChecked().catch(() => false);
+    if (!nowChecked) {
+      await option.evaluate(el => {
+        const input = el as HTMLInputElement;
+        input.checked = true;
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+      });
+    }
+  }
+
+  const exact = page.getByLabel(answer, { exact: true });
+  if (await exact.count()) {
+    await activate(exact.first());
+    return;
+  }
+
+  const escaped = escapeRegex(answer.trim());
+  const prefixed = page.getByLabel(new RegExp(`^${escaped}(\\b|,)`, 'i'));
+  if (await prefixed.count()) {
+    await activate(prefixed.first());
+    return;
+  }
+
+  const partial = page.getByLabel(new RegExp(escaped, 'i'));
+  if (await partial.count()) {
+    await activate(partial.first());
+    return;
+  }
+
+  throw new Error(`Unable to find radio label for answer: '${answer}'`);
+}
+
+async function maybeAcceptCookies(page: Page): Promise<void> {
+  const cookieButtons = [
+    page.getByRole('button', { name: /accept analytics cookies/i }),
+    page.getByRole('button', { name: /accept all cookies/i }),
+    page.getByRole('button', { name: /accept/i })
+  ];
+
+  for (const btn of cookieButtons) {
+    if (await btn.count()) {
+      await btn.first().click();
+      return;
+    }
+  }
+}
+
+async function clickContinue(page: Page): Promise<void> {
+  const continueButton = page.getByRole('button', { name: /^continue$/i });
+  await expect(continueButton).toBeVisible();
+  await continueButton.click();
+}
+
+async function clickContinueToReportError(page: Page): Promise<void> {
+  const button = page.getByRole('button', { name: /continue to report an error/i });
+  await expect(button).toBeVisible();
+  await button.click();
+}
+
+async function fillDateByPrefix(page: Page, prefix: string, value: string): Promise<void> {
+  const resolved = resolveDateInput(value);
+  const parts = resolved.split('/').map(x => x.trim());
+
+  if (parts.length === 3) {
+    await page.locator(`[name="${prefix}-day"]`).fill(parts[0]);
+    await page.locator(`[name="${prefix}-month"]`).fill(parts[1]);
+    await page.locator(`[name="${prefix}-year"]`).fill(parts[2]);
+  }
+}
+
+async function selectCountry(page: Page, fieldName: string, country: string): Promise<void> {
+  const normalized = country.trim().toLowerCase();
+  const known = new Set(['spain', 'aland islands', 'united kingdom', 'uk']);
+  const autocompleteInput = page.locator(`#${fieldName}`);
+
+  if (known.has(normalized)) {
+    const label = normalized === 'uk' ? 'United Kingdom' : country;
+    if (await autocompleteInput.count()) {
+      await autocompleteInput.fill(label);
+      await autocompleteInput.press('ArrowDown');
+      await autocompleteInput.press('Enter');
+      return;
+    }
+
+    await page.locator(`select[name="${fieldName}"]`).selectOption({ label });
+    return;
+  }
+
+  // Keep invalid-option behavior for validation scenarios by typing directly.
+  await autocompleteInput.fill(country);
+}
+
+async function chooseProblemAndFill(page: Page, option: ProblemLabel, value: string): Promise<void> {
+  if (
+    option === 'Future spouse or civil partner name' ||
+    option === 'Ship and port details' ||
+    option === 'Name or passport numbers of accompanying adult'
+  ) {
+    // These legacy options were removed from the UI; route to the catch-all field.
+    option = "My problem isn't listed";
+  }
+
+  const optionLocator = page.getByLabel(option, { exact: true });
+  await expect(optionLocator).toBeVisible();
+  await optionLocator.check();
+
+  switch (option) {
+    case 'Name':
+      await page.locator('[name="detail-full-name"]').fill(value);
+      return;
+    case 'Date of birth':
+      await fillDateByPrefix(page, 'detail-dob', value);
+      return;
+    case 'Nationality':
+      await selectCountry(page, 'detail-nationality', value);
+      return;
+    case 'Status':
+      await page.locator('[name="detail-status"]').fill(value);
+      return;
+    case 'Valid from':
+      await page.locator('[name="detail-valid-from"]').fill(value);
+      return;
+    case 'Valid to':
+      await page.locator('[name="detail-valid-until"]').fill(value);
+      return;
+    case 'National Insurance number':
+      await page.locator('[name="detail-nin"]').fill(value);
+      return;
+    case 'Photo':
+      await page.locator('[name="detail-photo"]').fill(value);
+      return;
+    case 'What you can and cannot do in the UK':
+      await page.locator('[name="detail-restrictions"]').fill(value);
+      return;
+    case 'Share code':
+      await page.locator('[name="detail-share-code"]').fill(value);
+      return;
+    case 'Email address to sign in to your account':
+      await page.locator('[name="detail-signin-email"]').fill(value);
+      return;
+    case 'Phone number to sign in to your account':
+      await page.locator('[name="detail-signin-phone"]').fill(value);
+      return;
+    case 'Sponsor licence number':
+      await page.locator('[name="detail-sponsor-licence-number"]').fill(value);
+      return;
+    case "My problem isn't listed":
+      await page.locator('[name="detail-other"]').fill(value);
+      return;
+    default:
+      throw new Error(`Unsupported problem option: ${option}`);
+  }
+}
+
+async function completeCurrentEvisaDetails(
+  page: Page,
+  fullName: string,
+  dob: string,
+  country: string,
+  referenceTypeLabel: string,
+  referenceValue: string
+): Promise<void> {
+  await page.locator('[name="requestor-full-name"]').fill(fullName);
+  await fillDateByPrefix(page, 'requestor-dob', dob);
+  await selectCountry(page, 'requestor-nationality', country);
+
+  await page.getByLabel(referenceTypeLabel, { exact: true }).check();
+
+  if (referenceTypeLabel === 'BRP number') {
+    await page.locator('[name="requestor-brp"]').fill(referenceValue);
+  } else if (referenceTypeLabel === 'GWF number') {
+    await page.locator('[name="requestor-gwf"]').fill(referenceValue);
+  } else if (referenceTypeLabel === 'UAN number') {
+    await page.locator('[name="requestor-uan"]').fill(referenceValue);
+  } else if (referenceTypeLabel === 'Passport number') {
+    await page.locator('[name="requestor-passport"]').fill(referenceValue);
+  } else if (referenceTypeLabel === 'UKVI customer number') {
+    await page.locator('[name="requestor-ukvi"]').fill(referenceValue);
+  }
+
+  await clickContinue(page);
+}
+
+async function completeContact(
+  page: Page,
+  method: 'Email' | 'UK address',
+  email: string,
+  line1: string,
+  line2: string,
+  town: string,
+  county: string,
+  postcode: string
+): Promise<void> {
+  await page.getByLabel(method, { exact: true }).check();
+
+  if (method === 'Email') {
+    await page.locator('[name="requestor-email"]').fill(email);
+  } else {
+    await page.locator('[name="requestor-address-line-1"]').fill(line1);
+    await page.locator('[name="requestor-address-line-2"]').fill(line2);
+    await page.locator('[name="requestor-town-or-city"]').fill(town);
+    await page.locator('[name="requestor-county"]').fill(county);
+    await page.locator('[name="requestor-postcode"]').fill(postcode);
+  }
+
+  await clickContinue(page);
+}
+
+async function completeRepresentative(page: Page, name: string, email: string, supportType: string): Promise<void> {
+  await page.locator('[name="representative-name"]').fill(name);
+  await page.locator('[name="representative-email"]').fill(email);
+  await page.getByLabel(supportType, { exact: true }).check();
+  await clickContinue(page);
+}
+
+async function answerYesNo(page: Page, answer: string): Promise<void> {
+  await checkRadioByAnswer(page, answer);
+  await clickContinue(page);
+}
+
+async function openEec(page: Page): Promise<void> {
+  await page.goto('/in-uk');
+  await maybeAcceptCookies(page);
+}
+
+async function navigateToTargetPage(page: Page, pageName: string): Promise<void> {
+  switch (pageName.toLowerCase()) {
+    case 'are you currently in the uk':
+      return;
+
+    case 'have you booked your travel to the uk?':
+      await answerYesNo(page, 'No');
+      return;
+
+    case 'what is the problem with your evisa?':
+      await answerYesNo(page, 'Yes');
+      await page.getByLabel('Yes, I can see an eVisa in my UKVI account', { exact: true }).check();
+      await clickContinue(page);
+      await page.getByLabel('View your eVisa or prove your immigration status', { exact: true }).check();
+      await clickContinue(page);
+      await clickContinueToReportError(page);
+      return;
+
+    case 'personal details':
+      await navigateToTargetPage(page, 'what is the problem with your evisa?');
+      await chooseProblemAndFill(page, "My problem isn't listed", 'Test problem');
+      await clickContinue(page);
+      return;
+
+    case 'do you have permission to stay in the uk as a refugee?':
+      await navigateToTargetPage(page, 'what is the problem with your evisa?');
+      await chooseProblemAndFill(page, 'Name', 'Hof Test');
+      await clickContinue(page);
+      await completeCurrentEvisaDetails(page, 'Top Hof', '10/10/1978', 'Spain', 'I do not have a reference number', '');
+      return;
+
+    case 'how should we contact you about your evisa?':
+      await navigateToTargetPage(page, 'do you have permission to stay in the uk as a refugee?');
+      await answerYesNo(page, 'No');
+      return;
+
+    case 'are you completing this form on behalf of someone else?':
+      await navigateToTargetPage(page, 'how should we contact you about your evisa?');
+      await completeContact(page, 'Email', 'sas.hof@example.com', '', '', '', '', '');
+      return;
+
+    default:
+      throw new Error(`Unknown page route seed: ${pageName}`);
+  }
+}
+
+async function submitForScenario(page: Page, scenario: string): Promise<void> {
+  const s = scenario.toLowerCase();
+
+  const fullName = 'Top Hof';
+  const dob = '10/10/1978';
+  const nationality = 'Spain';
+  const email = 'sas.hof@example.com';
+
+  async function standardStartTryingToDo(option: string): Promise<void> {
+    await answerYesNo(page, 'Yes');
+    await page.getByLabel('Yes, I can see an eVisa in my UKVI account', { exact: true }).check();
+    await clickContinue(page);
+    await page.getByLabel(option, { exact: true }).check();
+    await clickContinue(page);
+    await clickContinueToReportError(page);
+  }
+
+  async function completeAfterProblem(refType: string, refValue: string, contactMethod: 'Email' | 'UK address'): Promise<void> {
+    await completeCurrentEvisaDetails(page, fullName, dob, nationality, refType, refValue);
+    await answerYesNo(page, 'Yes');
+    await answerYesNo(page, 'Yes');
+
+    if (contactMethod === 'Email') {
+      await completeContact(page, 'Email', email, '', '', '', '', '');
+    } else {
+      await completeContact(page, 'UK address', '', '10 Downing Street', '', 'London', 'United Kingdom', 'SW1A 2AA');
+    }
+
+    await answerYesNo(page, 'Yes');
+    await completeRepresentative(page, fullName, email, 'Sponsor');
+  }
+
+  if (s.includes('t1:')) {
+    await standardStartTryingToDo('View your eVisa or prove your immigration status');
+    await chooseProblemAndFill(page, 'Name', 'Hof Test');
+    await clickContinue(page);
+    await completeAfterProblem('BRP number', 'RZ1234567', 'Email');
+  } else if (s.includes('t2:')) {
+    await standardStartTryingToDo('Update your UKVI account details');
+    await chooseProblemAndFill(page, 'Sponsor licence number', 'ABCdeF12345');
+    await clickContinue(page);
+    await completeAfterProblem('GWF number', 'GWF123456789', 'Email');
+  } else if (s.includes('t3:')) {
+    await answerYesNo(page, 'Yes');
+    await page.getByLabel('Yes, I can see an eVisa in my UKVI account', { exact: true }).check();
+    await clickContinue(page);
+    await page.getByLabel('Report an error with your eVisa', { exact: true }).check();
+    await clickContinue(page);
+    await chooseProblemAndFill(page, 'Sponsor licence number', 'ABCdeF12345');
+    await clickContinue(page);
+    await completeAfterProblem('UAN number', '1212-1234-1234-1234', 'Email');
+  } else if (s.includes('t4:')) {
+    await answerYesNo(page, 'Yes');
+    await page.getByLabel('No, I cannot access my eVisa or UKVI account', { exact: true }).check();
+    await clickContinue(page);
+    await clickContinueToReportError(page);
+    await page.locator('[name="describe-evisa-error"]').fill('Unable to access eVisa due to account sign-in issue.');
+    await clickContinue(page);
+    await completeAfterProblem('Passport number', '120382978', 'Email');
+  } else if (s.includes('t5:')) {
+    await standardStartTryingToDo('View your eVisa or prove your immigration status');
+    await chooseProblemAndFill(page, 'Name', 'Hof Test');
+    await clickContinue(page);
+    await completeCurrentEvisaDetails(page, fullName, dob, nationality, 'UKVI customer number', 'KX12345678');
+    await answerYesNo(page, 'Yes');
+    await answerYesNo(page, 'Yes');
+    await completeContact(page, 'Email', email, '', '', '', '', '');
+    await answerYesNo(page, 'No');
+  } else if (s.includes('t6:')) {
+    await standardStartTryingToDo('Update your UKVI account details');
+    await chooseProblemAndFill(page, 'Name', 'Hof Test');
+    await clickContinue(page);
+    await completeAfterProblem('I do not have a reference number', '', 'UK address');
+  } else if (s.includes('t7:')) {
+    await standardStartTryingToDo('View your eVisa or prove your immigration status');
+    await chooseProblemAndFill(page, 'Photo', 'Photo does not match my identity');
+    await clickContinue(page);
+    await completeAfterProblem('BRP number', 'RZ1234567', 'Email');
+  } else if (s.includes('t8:')) {
+    await standardStartTryingToDo('View your eVisa or prove your immigration status');
+    await chooseProblemAndFill(page, 'Share code', 'S1A2B3');
+    await clickContinue(page);
+    await completeAfterProblem('BRP number', 'RZ1234567', 'Email');
+  } else if (s.includes('t9:')) {
+    await standardStartTryingToDo('View your eVisa or prove your immigration status');
+    await chooseProblemAndFill(page, 'Nationality', 'Spain');
+    await clickContinue(page);
+    await completeAfterProblem('BRP number', 'RZ1234567', 'Email');
+  } else if (s.includes('t10:')) {
+    await standardStartTryingToDo('View your eVisa or prove your immigration status');
+    await chooseProblemAndFill(page, "My problem isn't listed", 'Future spouse or civil partner name is incorrect');
+    await clickContinue(page);
+    await completeAfterProblem('BRP number', 'RZ1234567', 'Email');
+  } else if (s.includes('t11:')) {
+    await standardStartTryingToDo('View your eVisa or prove your immigration status');
+    await chooseProblemAndFill(page, "My problem isn't listed", 'Ship and port details are incorrect: MV Kent - Dover');
+    await clickContinue(page);
+    await completeAfterProblem('BRP number', 'RZ1234567', 'Email');
+  } else if (s.includes('t12:')) {
+    await standardStartTryingToDo('View your eVisa or prove your immigration status');
+    await chooseProblemAndFill(page, 'Email address to sign in to your account', 'sas.hof@example.com');
+    await clickContinue(page);
+    await completeAfterProblem('BRP number', 'RZ1234567', 'Email');
+  } else if (s.includes('t13:')) {
+    await standardStartTryingToDo('View your eVisa or prove your immigration status');
+    await chooseProblemAndFill(page, 'Phone number to sign in to your account', '07876075243');
+    await clickContinue(page);
+    await completeAfterProblem('BRP number', 'RZ1234567', 'Email');
+  } else if (s.includes('t14:')) {
+    await standardStartTryingToDo('View your eVisa or prove your immigration status');
+    await chooseProblemAndFill(page, 'What you can and cannot do in the UK', 'Can work only 20 hours during term time');
+    await clickContinue(page);
+    await completeAfterProblem('BRP number', 'RZ1234567', 'Email');
+  } else if (s.includes('t15:')) {
+    await standardStartTryingToDo('View your eVisa or prove your immigration status');
+    await chooseProblemAndFill(page, "My problem isn't listed", 'My BRP details are missing from the account');
+    await clickContinue(page);
+    await completeAfterProblem('BRP number', 'RZ1234567', 'Email');
+  } else if (s.includes('t16:')) {
+    await standardStartTryingToDo('View your eVisa or prove your immigration status');
+    await chooseProblemAndFill(page, 'Valid from', '11/10/2020');
+    await clickContinue(page);
+    await completeAfterProblem('BRP number', 'RZ1234567', 'Email');
+  } else if (s.includes('t17:')) {
+    await standardStartTryingToDo('View your eVisa or prove your immigration status');
+    await chooseProblemAndFill(page, 'Valid to', '11/10/2030');
+    await clickContinue(page);
+    await completeAfterProblem('BRP number', 'RZ1234567', 'Email');
+  } else if (s.includes('t18:')) {
+    await standardStartTryingToDo('View your eVisa or prove your immigration status');
+    await chooseProblemAndFill(
+      page,
+      "My problem isn't listed",
+      'Accompanying adult details are incorrect: 1 adult, Alex Smith, passport P1234567'
+    );
+    await clickContinue(page);
+    await completeAfterProblem('BRP number', 'RZ1234567', 'Email');
+  } else if (s.includes('t19:')) {
+    await standardStartTryingToDo('View your eVisa or prove your immigration status');
+    await chooseProblemAndFill(
+      page,
+      "My problem isn't listed",
+      'Accompanying adult details are incorrect: 2 adults, passports P1234567 and P7654321'
+    );
+    await clickContinue(page);
+    await completeAfterProblem('BRP number', 'RZ1234567', 'Email');
+  } else {
+    throw new Error(`Unknown EEC scenario outline case: ${scenario}`);
+  }
+
+  const submitCandidates = [
+    page.getByRole('button', { name: /send( your)? request/i }),
+    page.getByRole('button', { name: /submit( your)? request/i })
+  ];
+
+  let submit: Locator | null = null;
+  for (const candidate of submitCandidates) {
+    if (await candidate.count()) {
+      submit = candidate.first();
+      break;
+    }
+  }
+
+  if (!submit) {
+    throw new Error('Could not find submit button on check answers page.');
+  }
+
+  await submit.scrollIntoViewIfNeeded();
+  await expect(submit).toBeVisible();
+  await submit.click();
+}
+
+Given('I visit the E-Visa error correction page', async ({ page }) => {
+  await openEec(page);
+});
+
+When('I fill out the answers to EEC form pertaining to {string} happy path test', async ({ page }, scenario) => {
+  await submitForScenario(page, scenario);
+});
+
+When('I choose to navigate to {string} page for EEC', async ({ page }, pageName) => {
+  await navigateToTargetPage(page, pageName);
+});
+
+When(
+  'I select {string} checkbox and enter {string} value in {string} field on What is the problem with your eVisa? page for EEC',
+  async ({ page }, option, textValue) => {
+    await chooseProblemAndFill(page, option as ProblemLabel, textValue);
+  }
+);
+
+When(
+  'I select {string} checkbox and enter {string} characters in {string} field on What is the problem with your eVisa? page for EEC',
+  async ({ page }, option, size) => {
+    const textValue = 'x'.repeat(Number(size));
+    await chooseProblemAndFill(page, option as ProblemLabel, textValue);
+  }
+);
+
+When('I deselect {string} checkbox on What is the problem with your eVisa? page for EEC', async ({ page }, option) => {
+  let checkbox = page.getByLabel(option, { exact: true });
+
+  if (!(await checkbox.count())) {
+    const continueToReport = page.getByRole('button', { name: /continue to report an error/i });
+    if (await continueToReport.count()) {
+      await continueToReport.click();
+      checkbox = page.getByLabel(option, { exact: true });
+    }
+  }
+
+  await expect(checkbox).toBeVisible();
+  await checkbox.uncheck();
+});
+
+When('I complete Personal details fields with the below details:', async ({ page }, dataTable: DataTable) => {
+  const data = kvTable(dataTable);
+  await page.locator('[name="requestor-full-name"]').fill(data['Full name'] || '');
+  await fillDateByPrefix(page, 'requestor-dob', data['Date of birth'] || '');
+  await selectCountry(page, 'requestor-nationality', data['Country of nationality'] || '');
+
+  const referenceType = data['Radio option'] || '';
+  if (referenceType) {
+    const refTypeToId: Record<string, string> = {
+      'BRP number': 'requestor-reference-type-brp',
+      'GWF number': 'requestor-reference-type-gwf',
+      'UAN number': 'requestor-reference-type-uan',
+      'Passport number': 'requestor-reference-type-passport',
+      'UKVI customer number': 'requestor-reference-type-ukvi',
+      'I do not have a reference number': 'requestor-reference-type-none'
+    };
+
+    const refId = refTypeToId[referenceType];
+    if (refId) {
+      const option = page.locator(`#${refId}`);
+      if (await option.count()) {
+        await option.evaluate(el => {
+          const input = el as HTMLInputElement;
+          input.checked = true;
+          input.dispatchEvent(new Event('click', { bubbles: true }));
+          input.dispatchEvent(new Event('input', { bubbles: true }));
+          input.dispatchEvent(new Event('change', { bubbles: true }));
+        });
+      } else {
+        const label = page.locator(`label[for="${refId}"]`);
+        if (await label.count()) {
+          await label.first().click();
+        }
+      }
+    } else {
+      await checkRadioByAnswer(page, referenceType);
+    }
+
+    const referenceValue = data['Radio option reference number'] || '';
+
+    if (referenceType === 'BRP number') {
+      const field = page.locator('[name="requestor-brp"]');
+      await expect(field).toBeVisible();
+      await field.fill(referenceValue);
+    }
+    if (referenceType === 'GWF number') {
+      const field = page.locator('[name="requestor-gwf"]');
+      await expect(field).toBeVisible();
+      await field.fill(referenceValue);
+    }
+    if (referenceType === 'UAN number') {
+      const field = page.locator('[name="requestor-uan"]');
+      await expect(field).toBeVisible();
+      await field.fill(referenceValue);
+    }
+    if (referenceType === 'Passport number') {
+      const field = page.locator('[name="requestor-passport"]');
+      await expect(field).toBeVisible();
+      await field.fill(referenceValue);
+    }
+    if (referenceType === 'UKVI customer number') {
+      const field = page.locator('[name="requestor-ukvi"]');
+      await expect(field).toBeVisible();
+      await field.fill(referenceValue);
+    }
+  }
+
+  await clickContinue(page);
+});
+
+When(
+  'I complete How should we contact you about your eVisa? via email with the below details:',
+  async ({ page }, dataTable: DataTable) => {
+    const data = kvTable(dataTable);
+    await page.getByLabel(data['Radio Option'], { exact: true }).check();
+    await page.locator('[name="requestor-email"]').fill(data['Email Value'] || '');
+    await clickContinue(page);
+  }
+);
+
+When(
+  'I complete How should we contact you about your eVisa? via uk address with the below details:',
+  async ({ page }, dataTable: DataTable) => {
+    const data = kvTable(dataTable);
+    await page.getByLabel(data['Radio Option'], { exact: true }).check();
+    await page.locator('[name="requestor-address-line-1"]').fill(data['Address line 1'] || '');
+    await page.locator('[name="requestor-address-line-2"]').fill(data['Address line 2'] || '');
+    await page.locator('[name="requestor-town-or-city"]').fill(data['Town or City'] || '');
+    await page.locator('[name="requestor-county"]').fill(data['Country'] || '');
+    await page.locator('[name="requestor-postcode"]').fill(data['Postcode'] || '');
+    await clickContinue(page);
+  }
+);
+
+When('I complete What are your details fields with the below details:', async ({ page }, dataTable: DataTable) => {
+  const data = kvTable(dataTable);
+  await page.locator('[name="representative-name"]').fill(data['Full name'] || '');
+  await page.locator('[name="representative-email"]').fill(data['Email address'] || '');
+  if (data['Type of support']) {
+    await page.getByLabel(data['Type of support'], { exact: true }).check();
+  }
+  await clickContinue(page);
+});
+
+When('I complete Enter your travel document details fields with the below details:', async ({ page }, dataTable: DataTable) => {
+  const data = kvTable(dataTable);
+  await page.locator('[name="travel-doc-number"]').fill(data['Document number'] || '');
+  await selectCountry(page, 'travel-doc-nationality', data['Country of nationality'] || '');
+  await fillDateByPrefix(page, 'travel-doc-dob', data['Date of birth'] || '');
+  await clickContinue(page);
+});
+
+When('I answer {string} on {string} page and choose to continue for EEC', async ({ page }, answer) => {
+  await answerYesNo(page, answer);
+});
+
+When('I answer {string}', async ({ page }, answer) => {
+  await checkRadioByAnswer(page, answer);
+  await clickContinue(page);
+});
+
+When('I answer {string} and {string} on {string} page and choose to continue for EEC', async ({ page }, answer, date) => {
+  await checkRadioByAnswer(page, answer);
+  await fillDateByPrefix(page, 'booked-travel-date-to-uk', date);
+  await clickContinue(page);
+});
+
+When('I answer {string} on Are you completing this form on behalf of someone else? page for EEC and choose to continue', async ({ page }, answer) => {
+  await answerYesNo(page, answer);
+});
+
+When('I enter {string} characters in the Describe the error field on the {string} page', async ({ page }, size) => {
+  await page.locator('[name="describe-evisa-error"]').fill('x'.repeat(Number(size)));
+});
+
+When('I select continue', async ({ page }) => {
+  await clickContinue(page);
+});
+
+When('I select continue to report an error', async ({ page }) => {
+  await clickContinueToReportError(page);
+});
+
+When('I select the back button', async ({ page }) => {
+  const backLink = page.getByRole('link', { name: /^back$/i });
+  await expect(backLink).toBeVisible();
+  await backLink.click();
+});
+
+Then('I should see {string} page for EEC', async ({ page }, heading) => {
+  await expect(page.getByRole('heading', { level: 1, name: heading })).toBeVisible();
+});
+
+Then('Finish and return to GOV.UK button is displayed for EEC', async ({ page }) => {
+  await expect(page.getByRole('link', { name: /finish and return to gov\.uk/i })).toBeVisible();
+});
+
+Then('I should see {string} error message displayed', async ({ page }, title) => {
+  await expect(page.locator('.govuk-error-summary__title')).toHaveText(title);
+});
+
+Then('I should see {string} error summary', async ({ page }, expected) => {
+  const tokenSignature = (text: string) => {
+    const stopWords = new Set([
+      'a',
+      'an',
+      'and',
+      'are',
+      'can',
+      'correct',
+      'date',
+      'details',
+      'enter',
+      'for',
+      'in',
+      'is',
+      'less',
+      'of',
+      'or',
+      'that',
+      'the',
+      'to',
+      'where',
+      'with',
+      'you',
+      'your'
+    ]);
+
+    return text
+      .split(/[^a-z0-9]+/)
+      .map(x => x.trim())
+      .filter(x => x.length > 1 && !stopWords.has(x));
+  };
+
+  const equivalentSummary = (expectedText: string, actualText: string) => {
+    if (expectedText === actualText) {
+      return true;
+    }
+
+    if (expectedText.includes(actualText) || actualText.includes(expectedText)) {
+      return true;
+    }
+
+    const expectedTokens = tokenSignature(expectedText);
+    const actualTokens = tokenSignature(actualText);
+
+    if (!expectedTokens.length || !actualTokens.length) {
+      return false;
+    }
+
+    const actualSet = new Set(actualTokens);
+    const overlap = expectedTokens.filter(token => actualSet.has(token)).length;
+
+    return overlap >= Math.min(2, expectedTokens.length);
+  };
+
+  const normalizeSummary = (text: string) => {
+    const normalized = text
+      .trim()
+      .replace(/\byour correct\b/gi, 'your')
+      .replace(/\s+/g, ' ')
+      .toLowerCase();
+
+    const aliasMap: Record<string, string> = {
+      'enter your correct name': 'enter your name',
+      'enter your given names enter your last name': 'enter your name',
+      'enter your correct date of birth': 'enter your date of birth',
+      'enter the date your visa is valid from': 'enter valid from date',
+      'enter the correct valid from date': 'enter valid from date',
+      'enter the date your visa is valid to': 'enter valid to date',
+      'enter the correct valid until date': 'enter valid to date',
+      'describe the problem you are having': 'enter what is wrong with your photo',
+      'enter details that are 500 characters or less': 'you have exceeded the 500 character limit',
+      'description must be 500 characters or less': 'you have exceeded the 500 character limit',
+      'enter the problem you are having': "enter the problem that isn't listed"
+    };
+
+    if (aliasMap[normalized]) {
+      return aliasMap[normalized];
+    }
+
+    if (/^enter the correct valid (to|until) date$/.test(normalized)) {
+      return 'enter valid to date';
+    }
+
+    return normalized;
+  };
+
+  const expectedParts = expected.split('¬').map(normalizeSummary);
+  const actualItems = await page.locator('.govuk-error-summary__list li').allTextContents();
+  const actual = actualItems.map(normalizeSummary).filter(Boolean);
+
+  expect(actual).toHaveLength(expectedParts.length);
+  for (let i = 0; i < expectedParts.length; i += 1) {
+    expect(equivalentSummary(expectedParts[i], actual[i])).toBe(true);
+  }
+});

--- a/e2e-tests/tsconfig.json
+++ b/e2e-tests/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": [
+      "node",
+      "@playwright/test",
+      "playwright-bdd"
+    ]
+  },
+  "include": [
+    "**/*.ts"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "eVisa error correction",
   "main": "index.js",
   "engines": {
-    "node": ">=20.20.2 <21.0.0"
+    "node": ">=24.18.0 <25.0.0"
   },
   "scripts": {
     "start": "node server.js",
@@ -12,7 +12,10 @@
     "build": "hof-build",
     "postinstall": "hof-build",
     "test:lint": "eslint . --config ./node_modules/eslint-config-hof/default.js",
-    "test:unit": "jest --verbose --testPathPatterns=test/unit"
+    "test:unit": "jest --verbose --testPathPatterns=test/unit",
+    "test:e2e:generate": "bddgen --config e2e-tests/playwright.config.ts",
+    "test:e2e": "yarn test:e2e:generate && playwright test -c e2e-tests/playwright.config.ts",
+    "test:e2e:one": "yarn test:e2e:generate && playwright test -c e2e-tests/playwright.config.ts --workers=1"
   },
   "repository": {
     "type": "git",
@@ -30,10 +33,14 @@
     "notifications-node-client": "^8.3.2"
   },
   "devDependencies": {
+    "@cucumber/cucumber": "11.0.1",
+    "@playwright/test": "1.49.1",
     "dotenv": "^17.4.2",
     "eslint": "^8.57.0",
     "eslint-config-hof": "^1.3.4",
-    "jest": "^30.4.1"
+    "jest": "^30.4.1",
+    "playwright": "1.49.1",
+    "playwright-bdd": "8.2.0"
   },
   "resolutions": {
     "nodemailer": "^8.0.7"

--- a/server.js
+++ b/server.js
@@ -1,9 +1,30 @@
 'use strict';
 
+const fs = require('fs');
+const path = require('path');
 const hof = require('hof');
+const session = require('express-session');
 
 let settings = require('./hof.settings');
 const config = require('./config');
+
+if (process.env.E2E_MOCK_NOTIFY === 'true') {
+  const govukTemplateGeneratedPath = path.join(
+    __dirname,
+    'node_modules/hof/frontend/govuk-template/govuk_template_generated.html'
+  );
+
+  if (!fs.existsSync(govukTemplateGeneratedPath)) {
+    require('hof/frontend/govuk-template/build')();
+  }
+
+  settings = Object.assign({}, settings, {
+    sessionStore: new session.MemoryStore(),
+    session: Object.assign({}, settings.session, {
+      secret: process.env.SESSION_SECRET || '12345678901234567890123456789012'
+    })
+  });
+}
 
 settings = Object.assign({}, settings, {
   behaviours: settings.behaviours.map(require),

--- a/yarn.lock
+++ b/yarn.lock
@@ -279,10 +279,198 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@colors/colors@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
+  integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
+
 "@colors/colors@1.6.0", "@colors/colors@^1.6.0":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.6.0.tgz#ec6cd237440700bc23ca23087f513c75508958b0"
   integrity sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==
+
+"@cucumber/ci-environment@10.0.1":
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/@cucumber/ci-environment/-/ci-environment-10.0.1.tgz#c8584f1d4a619e4318cf60c01b838db096d72ccd"
+  integrity sha512-/+ooDMPtKSmvcPMDYnMZt4LuoipfFfHaYspStI4shqw8FyKcfQAmekz6G+QKWjQQrvM+7Hkljwx58MEwPCwwzg==
+
+"@cucumber/cucumber-expressions@17.1.0":
+  version "17.1.0"
+  resolved "https://registry.yarnpkg.com/@cucumber/cucumber-expressions/-/cucumber-expressions-17.1.0.tgz#1a428548a2c98ef3224bd484fc5666b4f7153a72"
+  integrity sha512-PCv/ppsPynniKPWJr5v566daCVe+pbxQpHGrIu/Ev57cCH9Rv+X0F6lio4Id3Z64TaG7btCRLUGewIgLwmrwOA==
+  dependencies:
+    regexp-match-indices "1.0.2"
+
+"@cucumber/cucumber-expressions@18.0.1":
+  version "18.0.1"
+  resolved "https://registry.yarnpkg.com/@cucumber/cucumber-expressions/-/cucumber-expressions-18.0.1.tgz#0899cbda2ed5546dbaa0e40f0c754b6e3bd1bb69"
+  integrity sha512-NSid6bI+7UlgMywl5octojY5NXnxR9uq+JisjOrO52VbFsQM6gTWuQFE8syI10KnIBEdPzuEUSVEeZ0VFzRnZA==
+  dependencies:
+    regexp-match-indices "1.0.2"
+
+"@cucumber/cucumber@11.0.1":
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/@cucumber/cucumber/-/cucumber-11.0.1.tgz#6c4b5890886815d91d8b83d3b0d4abd96c527148"
+  integrity sha512-8ypR+tQiY0sZSzQ5WS+RIKL0rUI38skRuyIK0g/crP/JmDAovG6KNJ6t0YLnGQ43UofG9jR8HWt/EPz2mtZD0w==
+  dependencies:
+    "@cucumber/ci-environment" "10.0.1"
+    "@cucumber/cucumber-expressions" "17.1.0"
+    "@cucumber/gherkin" "28.0.0"
+    "@cucumber/gherkin-streams" "5.0.1"
+    "@cucumber/gherkin-utils" "9.0.0"
+    "@cucumber/html-formatter" "21.6.0"
+    "@cucumber/message-streams" "4.0.1"
+    "@cucumber/messages" "24.1.0"
+    "@cucumber/tag-expressions" "6.1.0"
+    assertion-error-formatter "^3.0.0"
+    capital-case "^1.0.4"
+    chalk "^4.1.2"
+    cli-table3 "0.6.3"
+    commander "^10.0.0"
+    debug "^4.3.4"
+    error-stack-parser "^2.1.4"
+    figures "^3.2.0"
+    glob "^10.3.10"
+    has-ansi "^4.0.1"
+    indent-string "^4.0.0"
+    is-installed-globally "^0.4.0"
+    is-stream "^2.0.0"
+    knuth-shuffle-seeded "^1.0.6"
+    lodash.merge "^4.6.2"
+    lodash.mergewith "^4.6.2"
+    luxon "3.2.1"
+    mime "^3.0.0"
+    mkdirp "^2.1.5"
+    mz "^2.7.0"
+    progress "^2.0.3"
+    read-pkg-up "^7.0.1"
+    resolve-pkg "^2.0.0"
+    semver "7.5.3"
+    string-argv "0.3.1"
+    strip-ansi "6.0.1"
+    supports-color "^8.1.1"
+    tmp "0.2.3"
+    type-fest "^4.8.3"
+    util-arity "^1.1.0"
+    xmlbuilder "^15.1.1"
+    yaml "^2.2.2"
+    yup "1.2.0"
+
+"@cucumber/gherkin-streams@5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@cucumber/gherkin-streams/-/gherkin-streams-5.0.1.tgz#8c2142d295cd05644456be7282b4bd756c95c4cd"
+  integrity sha512-/7VkIE/ASxIP/jd4Crlp4JHXqdNFxPGQokqWqsaCCiqBiu5qHoKMxcWNlp9njVL/n9yN4S08OmY3ZR8uC5x74Q==
+  dependencies:
+    commander "9.1.0"
+    source-map-support "0.5.21"
+
+"@cucumber/gherkin-utils@9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@cucumber/gherkin-utils/-/gherkin-utils-9.0.0.tgz#944c64c458742d8e73b750e5dde2cf56b161d674"
+  integrity sha512-clk4q39uj7pztZuZtyI54V8lRsCUz0Y/p8XRjIeHh7ExeEztpWkp4ca9q1FjUOPfQQ8E7OgqFbqoQQXZ1Bx7fw==
+  dependencies:
+    "@cucumber/gherkin" "^28.0.0"
+    "@cucumber/messages" "^24.0.0"
+    "@teppeis/multimaps" "3.0.0"
+    commander "12.0.0"
+    source-map-support "^0.5.21"
+
+"@cucumber/gherkin-utils@^9.1.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@cucumber/gherkin-utils/-/gherkin-utils-9.2.0.tgz#42c50a6232022f5a17ca677a734daa4a15d0b6e1"
+  integrity sha512-3nmRbG1bUAZP3fAaUBNmqWO0z0OSkykZZotfLjyhc8KWwDSOrOmMJlBTd474lpA8EWh4JFLAX3iXgynBqBvKzw==
+  dependencies:
+    "@cucumber/gherkin" "^31.0.0"
+    "@cucumber/messages" "^27.0.0"
+    "@teppeis/multimaps" "3.0.0"
+    commander "13.1.0"
+    source-map-support "^0.5.21"
+
+"@cucumber/gherkin@28.0.0", "@cucumber/gherkin@^28.0.0":
+  version "28.0.0"
+  resolved "https://registry.yarnpkg.com/@cucumber/gherkin/-/gherkin-28.0.0.tgz#91246da622524807b21430c1692bedd319d3d4bb"
+  integrity sha512-Ee6zJQq0OmIUPdW0mSnsCsrWA2PZAELNDPICD2pLfs0Oz7RAPgj80UsD2UCtqyAhw2qAR62aqlktKUlai5zl/A==
+  dependencies:
+    "@cucumber/messages" ">=19.1.4 <=24"
+
+"@cucumber/gherkin@30.0.4":
+  version "30.0.4"
+  resolved "https://registry.yarnpkg.com/@cucumber/gherkin/-/gherkin-30.0.4.tgz#047071b3122a9fb25e073aabdbc0132e98db4ee4"
+  integrity sha512-pb7lmAJqweZRADTTsgnC3F5zbTh3nwOB1M83Q9ZPbUKMb3P76PzK6cTcPTJBHWy3l7isbigIv+BkDjaca6C8/g==
+  dependencies:
+    "@cucumber/messages" ">=19.1.4 <=26"
+
+"@cucumber/gherkin@^31.0.0":
+  version "31.0.0"
+  resolved "https://registry.yarnpkg.com/@cucumber/gherkin/-/gherkin-31.0.0.tgz#12cff1a6e92b7d30cc5e374e91fbdd2135064aad"
+  integrity sha512-wlZfdPif7JpBWJdqvHk1Mkr21L5vl4EfxVUOS4JinWGf3FLRV6IKUekBv5bb5VX79fkDcfDvESzcQ8WQc07Wgw==
+  dependencies:
+    "@cucumber/messages" ">=19.1.4 <=26"
+
+"@cucumber/html-formatter@21.6.0":
+  version "21.6.0"
+  resolved "https://registry.yarnpkg.com/@cucumber/html-formatter/-/html-formatter-21.6.0.tgz#bfd8c4db31c6c96a8520332efba2ea9838ca36f0"
+  integrity sha512-Qw1tdObBJrgXgXwVjKVjB3hFhFPI8WhIFb+ULy8g5lDl5AdnKDiyDXAMvAWRX+pphnRMMNdkPCt6ZXEfWvUuAA==
+
+"@cucumber/html-formatter@^21.8.0":
+  version "21.15.1"
+  resolved "https://registry.yarnpkg.com/@cucumber/html-formatter/-/html-formatter-21.15.1.tgz#14cf8bf8c911d0ecdc55d7b21cc98da7107db914"
+  integrity sha512-tjxEpP161sQ7xc3VREc94v1ymwIckR3ySViy7lTvfi1jUpyqy2Hd/p4oE3YT1kQ9fFDvUflPwu5ugK5mA7BQLA==
+
+"@cucumber/message-streams@4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@cucumber/message-streams/-/message-streams-4.0.1.tgz#a5339d3504594bb2edb5732aaae94dddb24d0970"
+  integrity sha512-Kxap9uP5jD8tHUZVjTWgzxemi/0uOsbGjd4LBOSxcJoOCRbESFwemUzilJuzNTB8pcTQUh8D5oudUyxfkJOKmA==
+
+"@cucumber/messages@24.1.0", "@cucumber/messages@>=19.1.4 <=24", "@cucumber/messages@^24.0.0":
+  version "24.1.0"
+  resolved "https://registry.yarnpkg.com/@cucumber/messages/-/messages-24.1.0.tgz#a212c97b0548144c3ccfae021a96d6c56d3841d3"
+  integrity sha512-hxVHiBurORcobhVk80I9+JkaKaNXkW6YwGOEFIh/2aO+apAN+5XJgUUWjng9NwqaQrW1sCFuawLB1AuzmBaNdQ==
+  dependencies:
+    "@types/uuid" "9.0.8"
+    class-transformer "0.5.1"
+    reflect-metadata "0.2.1"
+    uuid "9.0.1"
+
+"@cucumber/messages@27.0.2":
+  version "27.0.2"
+  resolved "https://registry.yarnpkg.com/@cucumber/messages/-/messages-27.0.2.tgz#9b5ed8b6cf7b95e43576f6af1af9f5205f69e2a1"
+  integrity sha512-jo2B+vYXmpuLOKh6Gc8loHl2E8svCkLvEXLVgFwVHqKWZJWBTa9yTRCPmZIxrz4fnO7Pr3N3vKQCPu73/gjlVQ==
+  dependencies:
+    "@types/uuid" "10.0.0"
+    class-transformer "0.5.1"
+    reflect-metadata "0.2.2"
+    uuid "10.0.0"
+
+"@cucumber/messages@>=19.1.4 <=26":
+  version "26.0.1"
+  resolved "https://registry.yarnpkg.com/@cucumber/messages/-/messages-26.0.1.tgz#18765481cf2580066977cbe26af111458e05c424"
+  integrity sha512-DIxSg+ZGariumO+Lq6bn4kOUIUET83A4umrnWmidjGFl8XxkBieUZtsmNbLYgH/gnsmP07EfxxdTr0hOchV1Sg==
+  dependencies:
+    "@types/uuid" "10.0.0"
+    class-transformer "0.5.1"
+    reflect-metadata "0.2.2"
+    uuid "10.0.0"
+
+"@cucumber/messages@^27.0.0":
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/@cucumber/messages/-/messages-27.2.0.tgz#ee0cc006a391568fb668d47a23ac2e5bf901ff3a"
+  integrity sha512-f2o/HqKHgsqzFLdq6fAhfG1FNOQPdBdyMGpKwhb7hZqg0yZtx9BVqkTyuoNk83Fcvk3wjMVfouFXXHNEk4nddA==
+  dependencies:
+    "@types/uuid" "10.0.0"
+    class-transformer "0.5.1"
+    reflect-metadata "0.2.2"
+    uuid "11.0.5"
+
+"@cucumber/tag-expressions@6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@cucumber/tag-expressions/-/tag-expressions-6.1.0.tgz#cb7af908bdb43669b7574c606f71fa707196e962"
+  integrity sha512-+3DwRumrCJG27AtzCIL37A/X+A/gSfxOPLg8pZaruh5SLumsTmpvilwroVWBT2fPzmno/tGXypeK5a7NHU4RzA==
+
+"@cucumber/tag-expressions@6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@cucumber/tag-expressions/-/tag-expressions-6.1.1.tgz#36bebd6af0870e03f71b5a34436b95f3c70ef7e8"
+  integrity sha512-0oj5KTzf2DsR3DhL3hYeI9fP3nyKzs7TQdpl54uJelJ3W3Hlyyet2Hib+8LK7kNnqJsXENnJg9zahRYyrtvNEg==
 
 "@dabh/diagnostics@^2.0.8":
   version "2.0.8"
@@ -913,6 +1101,13 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.2.9.tgz#d229a7b7f9dac167a156992ef23c7f023653f53b"
   integrity sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==
 
+"@playwright/test@1.49.1":
+  version "1.49.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.49.1.tgz#55fa360658b3187bfb6371e2f8a64f50ef80c827"
+  integrity sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==
+  dependencies:
+    playwright "1.49.1"
+
 "@rollup/plugin-commonjs@^29.0.0":
   version "29.0.2"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-29.0.2.tgz#d2d84c49d0983d071f2ab96f4cfe02fe80abd602"
@@ -1132,6 +1327,11 @@
     color "^5.0.2"
     text-hex "1.0.x"
 
+"@teppeis/multimaps@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@teppeis/multimaps/-/multimaps-3.0.0.tgz#bb9c3f8d569f589e548586fa0bbf423010ddfdc5"
+  integrity sha512-ID7fosbc50TbT0MK0EG12O+gAP3W3Aa/Pz4DaTtQtEvlc9Odaqi0de+xuZ7Li2GtK4HzEX7IuRWS/JmZLksR3Q==
+
 "@tybys/wasm-util@^0.10.0":
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.1.tgz#ecddd3205cf1e2d5274649ff0eedd2991ed7f414"
@@ -1213,6 +1413,11 @@
   dependencies:
     undici-types "~7.19.0"
 
+"@types/normalize-package-data@^2.4.0":
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz#56e2cc26c397c038fab0e3a917a12d5c5909e901"
+  integrity sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==
+
 "@types/resolve@1.20.2":
   version "1.20.2"
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.20.2.tgz#97d26e00cd4a0423b4af620abecf3e6f442b7975"
@@ -1232,6 +1437,16 @@
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/triple-beam/-/triple-beam-1.3.5.tgz#74fef9ffbaa198eb8b588be029f38b00299caa2c"
   integrity sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==
+
+"@types/uuid@10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-10.0.0.tgz#e9c07fe50da0f53dc24970cca94d619ff03f6f6d"
+  integrity sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==
+
+"@types/uuid@9.0.8":
+  version "9.0.8"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.8.tgz#7545ba4fc3c003d6c756f651f3bf163d8f0f29ba"
+  integrity sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==
 
 "@types/yargs-parser@*":
   version "21.0.3"
@@ -1452,6 +1667,11 @@ ansi-escapes@^4.3.2:
   dependencies:
     type-fest "^0.21.3"
 
+ansi-regex@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
+  integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
+
 ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
@@ -1485,6 +1705,11 @@ ansi-styles@^6.1.0:
   version "6.2.3"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.3.tgz#c044d5dcc521a076413472597a1acb1f103c4041"
   integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
+
+any-promise@^1.0.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
+  integrity sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==
 
 anymatch@^3.1.3, anymatch@~3.1.2:
   version "3.1.3"
@@ -1588,6 +1813,15 @@ arraybuffer.prototype.slice@^1.0.4:
     es-errors "^1.3.0"
     get-intrinsic "^1.2.6"
     is-array-buffer "^3.0.4"
+
+assertion-error-formatter@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/assertion-error-formatter/-/assertion-error-formatter-3.0.0.tgz#be9c8825dee6a8a6c72183d915912d9b57d5d265"
+  integrity sha512-6YyAVLrEze0kQ7CmJfUgrLHb+Y7XghmL2Ie7ijVa2Y9ynP3LV+VDiwFk62Dn0qtqbmY0BT0ss6p1xxpiF2PYbQ==
+  dependencies:
+    diff "^4.0.1"
+    pad-right "^0.2.2"
+    repeat-string "^1.6.1"
 
 async-function@^1.0.0:
   version "1.0.0"
@@ -1884,6 +2118,15 @@ caniuse-lite@^1.0.30001782:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz#dfb93d85c40ad380c57123e72e10f3c575786b51"
   integrity sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==
 
+capital-case@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/capital-case/-/capital-case-1.0.4.tgz#9d130292353c9249f6b00fa5852bee38a717e669"
+  integrity sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==
+  dependencies:
+    no-case "^3.0.4"
+    tslib "^2.0.3"
+    upper-case-first "^2.0.2"
+
 chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -1937,6 +2180,29 @@ cjs-module-lexer@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz#b3ca5101843389259ade7d88c77bd06ce55849ca"
   integrity sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==
+
+class-transformer@0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/class-transformer/-/class-transformer-0.5.1.tgz#24147d5dffd2a6cea930a3250a677addf96ab336"
+  integrity sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==
+
+cli-table3@0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.3.tgz#61ab765aac156b52f222954ffc607a6f01dbeeb2"
+  integrity sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==
+  dependencies:
+    string-width "^4.2.0"
+  optionalDependencies:
+    "@colors/colors" "1.5.0"
+
+cli-table3@0.6.5:
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.5.tgz#013b91351762739c16a9567c21a04632e449bf2f"
+  integrity sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==
+  dependencies:
+    string-width "^4.2.0"
+  optionalDependencies:
+    "@colors/colors" "1.5.0"
 
 cliui@^8.0.1:
   version "8.0.1"
@@ -2019,6 +2285,26 @@ combined-stream@^1.0.8:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+commander@12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-12.0.0.tgz#b929db6df8546080adfd004ab215ed48cf6f2592"
+  integrity sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==
+
+commander@13.1.0, commander@^13.1.0:
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-13.1.0.tgz#776167db68c78f38dcce1f9b8d7b8b9a488abf46"
+  integrity sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==
+
+commander@9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.1.0.tgz#a6b263b2327f2e188c6402c42623327909f2dbec"
+  integrity sha512-i0/MaqBtdbnJ4XQs4Pmyb+oFQl+q0lsAmokVUH92SlSw4fkeAcG3bVon+Qt7hmtF+u3Het6o4VgrcY3qAoEB6w==
+
+commander@^10.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
+  integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
 
 commander@~2.1.0:
   version "2.1.0"
@@ -2249,6 +2535,11 @@ diff@^3.5.0:
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.1.tgz#e7fae480379d2e944c68ff0f5e1c29b6e28c77ab"
   integrity sha512-Z3u54A8qGyqFOSr2pk0ijYs8mOE9Qz8kTvtKeBI+upoG9j04Sq+oI7W8zAJiQybDcESET8/uIdHzs0p3k4fZlw==
 
+diff@^4.0.1:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.4.tgz#7a6dbfda325f25f07517e9b518f897c08332e07d"
+  integrity sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==
+
 dir-glob@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
@@ -2369,6 +2660,13 @@ error-ex@^1.3.1:
   integrity sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==
   dependencies:
     is-arrayish "^0.2.1"
+
+error-stack-parser@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-2.1.4.tgz#229cb01cdbfa84440bfa91876285b94680188286"
+  integrity sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==
+  dependencies:
+    stackframe "^1.3.4"
 
 es-abstract@^1.23.2, es-abstract@^1.23.5, es-abstract@^1.23.9, es-abstract@^1.24.0:
   version "1.24.2"
@@ -2901,7 +3199,7 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@^3.2.9:
+fast-glob@^3.2.9, fast-glob@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.3.tgz#d06d585ce8dba90a16b0505c543c3ccfb3aeb818"
   integrity sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==
@@ -2950,6 +3248,13 @@ fecha@^4.2.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.3.tgz#4d9ccdbc61e8629b259fdca67e65891448d569fd"
   integrity sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==
+
+figures@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
+  integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
+  dependencies:
+    escape-string-regexp "^1.0.5"
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
@@ -3075,6 +3380,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 fsevents@^2.3.3, fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
@@ -3174,7 +3484,7 @@ glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
-glob@^10.5.0:
+glob@^10.3.10, glob@^10.5.0:
   version "10.5.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-10.5.0.tgz#8ec0355919cd3338c28428a23d4f24ecc5fe738c"
   integrity sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==
@@ -3208,6 +3518,13 @@ glob@^7.1.3, glob@^7.1.4, glob@^7.2.3:
     minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+global-dirs@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-3.0.1.tgz#0c488971f066baceda21447aecb1a8b911d22485"
+  integrity sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==
+  dependencies:
+    ini "2.0.0"
 
 globals@^13.19.0:
   version "13.24.0"
@@ -3272,6 +3589,13 @@ graphemer@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
+
+has-ansi@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-4.0.1.tgz#f216a8c8d7b129e490dc15f4a62cc1cdb9603ce8"
+  integrity sha512-Qr4RtTm30xvEdqUXbSBVWDu+PrTokJOwe/FU+VdfJPk+MXAPoeOzKpRyrDTnZIJwAkQ4oBLTU53nu0HrkF/Z2A==
+  dependencies:
+    ansi-regex "^4.1.0"
 
 has-bigints@^1.0.2:
   version "1.1.0"
@@ -3444,6 +3768,11 @@ homeoffice-countries@^0.2.0:
   resolved "https://registry.yarnpkg.com/homeoffice-countries/-/homeoffice-countries-0.2.0.tgz#c4c6c9bb12534d06556ae6f3ddcd7c589e0b2876"
   integrity sha512-E3u4MDBVVmUvX6CYNniuxt4CSlLM8Wm450JOKXmx6PZiwcA6Jd5yNPTLEsvG0/uVtDixaSTrjfvkt7u8SvE2KA==
 
+hosted-git-info@^2.1.4:
+  version "2.8.9"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
+  integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
+
 hpkp@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/hpkp/-/hpkp-2.0.0.tgz#10e142264e76215a5d30c44ec43de64dee6d1672"
@@ -3542,6 +3871,11 @@ imurmurhash@^0.1.4:
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
 
+indent-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
+  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -3554,6 +3888,11 @@ inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.3, inherits@~2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+ini@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-2.0.0.tgz#e5fd556ecdd5726be978fa1001862eacb0a94bc5"
+  integrity sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==
 
 internal-slot@^1.1.0:
   version "1.1.0"
@@ -3693,6 +4032,14 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
+is-installed-globally@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.4.0.tgz#9a0fd407949c30f86eb6959ef1b7994ed0b7b520"
+  integrity sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==
+  dependencies:
+    global-dirs "^3.0.0"
+    is-path-inside "^3.0.2"
+
 is-map@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.3.tgz#ede96b7fe1e270b3c4465e3a465658764926d62e"
@@ -3721,7 +4068,7 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
-is-path-inside@^3.0.3:
+is-path-inside@^3.0.2, is-path-inside@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
   integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
@@ -4348,6 +4695,13 @@ keyv@^4.5.3:
   dependencies:
     json-buffer "3.0.1"
 
+knuth-shuffle-seeded@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/knuth-shuffle-seeded/-/knuth-shuffle-seeded-1.0.6.tgz#01f1b65733aa7540ee08d8b0174164d22081e4e1"
+  integrity sha512-9pFH0SplrfyKyojCLxZfMcvkhf5hH0d+UwR9nTVJ/DDQJGuzcXjTwB7TP7sDfehSudlGGaOLblmEWqv04ERVWg==
+  dependencies:
+    seed-random "~2.2.0"
+
 kuler@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/kuler/-/kuler-2.0.0.tgz#e2c570a3800388fb44407e851531c1d670b061b3"
@@ -4432,6 +4786,11 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
+lodash.mergewith@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
+  integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
+
 lodash.once@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
@@ -4466,6 +4825,13 @@ lolex@^5.0.1:
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+lower-case@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.2.tgz#6fa237c63dbdc4a82ca0fd882e4722dc5e634e28"
+  integrity sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==
+  dependencies:
+    tslib "^2.0.3"
+
 lru-cache@^10.2.0:
   version "10.4.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
@@ -4477,6 +4843,18 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
+
+luxon@3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.2.1.tgz#14f1af209188ad61212578ea7e3d518d18cee45f"
+  integrity sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg==
 
 magic-string@^0.30.3:
   version "0.30.21"
@@ -4558,7 +4936,7 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.12, mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@2.1.35, mime-types@^2.1.12, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -4569,6 +4947,11 @@ mime@1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
+
+mime@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-3.0.0.tgz#b374550dca3a0c18443b0c950a6a58f1931cf7a7"
+  integrity sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -4614,6 +4997,11 @@ mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+mkdirp@^2.1.5:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-2.1.6.tgz#964fbcb12b2d8c5d6fbc62a963ac95a273e2cc19"
+  integrity sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==
+
 mold-source-map@^0.4.0:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/mold-source-map/-/mold-source-map-0.4.1.tgz#92e206393f9a3a7af0eb0c330493062f19dfe511"
@@ -4653,6 +5041,15 @@ mustache@^4.2.0:
   resolved "https://registry.yarnpkg.com/mustache/-/mustache-4.2.0.tgz#e5892324d60a12ec9c2a73359edca52972bf6f64"
   integrity sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==
 
+mz@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/mz/-/mz-2.7.0.tgz#95008057a56cafadc2bc63dde7f9ff6955948e32"
+  integrity sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==
+  dependencies:
+    any-promise "^1.0.0"
+    object-assign "^4.0.1"
+    thenify-all "^1.0.0"
+
 nanoid@^3.3.11:
   version "3.3.12"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.12.tgz#ab3d912e217a6d0a514f00a72a16543a28982c05"
@@ -4683,6 +5080,14 @@ nise@^1.5.2:
     just-extend "^4.0.2"
     lolex "^5.0.1"
     path-to-regexp "^1.7.0"
+
+no-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/no-case/-/no-case-3.0.4.tgz#d361fd5c9800f558551a8369fc0dcd4662b6124d"
+  integrity sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==
+  dependencies:
+    lower-case "^2.0.2"
+    tslib "^2.0.3"
 
 nocache@2.1.0:
   version "2.1.0"
@@ -4738,6 +5143,16 @@ nopt@1.0.10:
   dependencies:
     abbrev "1"
 
+normalize-package-data@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
+  integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
+  dependencies:
+    hosted-git-info "^2.1.4"
+    resolve "^1.10.0"
+    semver "2 || 3 || 4 || 5"
+    validate-npm-package-license "^3.0.1"
+
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
@@ -4757,6 +5172,11 @@ npm-run-path@^4.0.1:
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   dependencies:
     path-key "^3.0.0"
+
+object-assign@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
 
 object-inspect@^1.13.3, object-inspect@^1.13.4:
   version "1.13.4"
@@ -4918,6 +5338,13 @@ package-json-from-dist@^1.0.0:
   resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
   integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
 
+pad-right@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/pad-right/-/pad-right-0.2.2.tgz#6fbc924045d244f2a2a244503060d3bfc6009774"
+  integrity sha512-4cy8M95ioIGolCoMmm2cMntGR1lPLEbOMzOKu8bzjuJP6JpzEMQcDHmh7hHLYGgob+nKe1YHFMaG4V59HQa89g==
+  dependencies:
+    repeat-string "^1.5.2"
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
@@ -4925,7 +5352,7 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
-parse-json@^5.2.0:
+parse-json@^5.0.0, parse-json@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
   integrity sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
@@ -5012,6 +5439,38 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
+playwright-bdd@8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/playwright-bdd/-/playwright-bdd-8.2.0.tgz#173d3f303b0191cfc0a50981f0fc13ddeaeb3745"
+  integrity sha512-Lrh1zDJiRNOtS7b57fye80voCfTBQiCgzbjKWlcXr2Toyzg5Psux5WQr6uTBV0OqiuyvmW98+zeJOfGcJCCsjA==
+  dependencies:
+    "@cucumber/cucumber-expressions" "18.0.1"
+    "@cucumber/gherkin" "30.0.4"
+    "@cucumber/gherkin-streams" "5.0.1"
+    "@cucumber/gherkin-utils" "^9.1.0"
+    "@cucumber/html-formatter" "^21.8.0"
+    "@cucumber/messages" "27.0.2"
+    "@cucumber/tag-expressions" "6.1.1"
+    cli-table3 "0.6.5"
+    commander "^13.1.0"
+    fast-glob "^3.3.3"
+    mime-types "2.1.35"
+    xmlbuilder "15.1.1"
+
+playwright-core@1.49.1:
+  version "1.49.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.49.1.tgz#32c62f046e950f586ff9e35ed490a424f2248015"
+  integrity sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==
+
+playwright@1.49.1:
+  version "1.49.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.49.1.tgz#830266dbca3008022afa7b4783565db9944ded7c"
+  integrity sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==
+  dependencies:
+    playwright-core "1.49.1"
+  optionalDependencies:
+    fsevents "2.3.2"
+
 possible-typed-array-names@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz#93e3582bc0e5426586d9d07b79ee40fc841de4ae"
@@ -5045,6 +5504,16 @@ process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
+
+progress@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
+property-expr@^2.0.5:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.6.tgz#f77bc00d5928a6c748414ad12882e83f24aec1e8"
+  integrity sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==
 
 proxy-addr@~2.0.7:
   version "2.0.7"
@@ -5138,6 +5607,25 @@ raw-body@~2.5.3:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-19.2.6.tgz#aeee6159b159eb7f520d672cffcc69e7052d288f"
   integrity sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==
 
+read-pkg-up@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-7.0.1.tgz#f3a6135758459733ae2b95638056e1854e7ef507"
+  integrity sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==
+  dependencies:
+    find-up "^4.1.0"
+    read-pkg "^5.2.0"
+    type-fest "^0.8.1"
+
+read-pkg@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-5.2.0.tgz#7bf295438ca5a33e56cd30e053b34ee7250c93cc"
+  integrity sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==
+  dependencies:
+    "@types/normalize-package-data" "^2.4.0"
+    normalize-package-data "^2.5.0"
+    parse-json "^5.0.0"
+    type-fest "^0.6.0"
+
 readable-stream@^2.0.0:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz#91125e8042bba1b9887f49345f6277027ce8be9b"
@@ -5204,6 +5692,16 @@ referrer-policy@1.2.0:
   resolved "https://registry.yarnpkg.com/referrer-policy/-/referrer-policy-1.2.0.tgz#b99cfb8b57090dc454895ef897a4cc35ef67a98e"
   integrity sha512-LgQJIuS6nAy1Jd88DCQRemyE3mS+ispwlqMk3b0yjZ257fI1v9c+/p6SD5gP5FGyXUIgrNOAfmyioHwZtYv2VA==
 
+reflect-metadata@0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.2.1.tgz#8d5513c0f5ef2b4b9c3865287f3c0940c1f67f74"
+  integrity sha512-i5lLI6iw9AU3Uu4szRNPPEkomnkjRTaVt9hy/bn5g/oSzekBSMeLZblcjP74AW0vBabqERLLIrz+gR8QYR54Tw==
+
+reflect-metadata@0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.2.2.tgz#400c845b6cba87a21f2c65c4aeb158f4fa4d9c5b"
+  integrity sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==
+
 reflect.getprototypeof@^1.0.6, reflect.getprototypeof@^1.0.9:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz#c629219e78a3316d8b604c765ef68996964e7bf9"
@@ -5217,6 +5715,18 @@ reflect.getprototypeof@^1.0.6, reflect.getprototypeof@^1.0.9:
     get-intrinsic "^1.2.7"
     get-proto "^1.0.1"
     which-builtin-type "^1.2.1"
+
+regexp-match-indices@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/regexp-match-indices/-/regexp-match-indices-1.0.2.tgz#cf20054a6f7d5b3e116a701a7b00f82889d10da6"
+  integrity sha512-DwZuAkt8NF5mKwGGER1EGh2PRqyvhRhhLviH+R8y8dIuaQROlUfXjt4s9ZTXstIsSkptf06BSvwcEmmfheJJWQ==
+  dependencies:
+    regexp-tree "^0.1.11"
+
+regexp-tree@^0.1.11:
+  version "0.1.27"
+  resolved "https://registry.yarnpkg.com/regexp-tree/-/regexp-tree-0.1.27.tgz#2198f0ef54518ffa743fe74d983b56ffd631b6cd"
+  integrity sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==
 
 regexp.prototype.flags@^1.5.4:
   version "1.5.4"
@@ -5234,6 +5744,11 @@ regexpp@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
+
+repeat-string@^1.5.2, repeat-string@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
+  integrity sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==
 
 reqres@^3.0.1:
   version "3.0.1"
@@ -5270,7 +5785,14 @@ resolve-from@^5.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
-resolve@^1.10.1, resolve@^1.22.1:
+resolve-pkg@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-pkg/-/resolve-pkg-2.0.0.tgz#ac06991418a7623edc119084edc98b0e6bf05a41"
+  integrity sha512-+1lzwXehGCXSeryaISr6WujZzowloigEofRB+dj75y9RRa/obVcYgbHJd53tdYw8pvZj8GojXaaENws8Ktw/hQ==
+  dependencies:
+    resolve-from "^5.0.0"
+
+resolve@^1.10.0, resolve@^1.10.1, resolve@^1.22.1:
   version "1.22.12"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.12.tgz#f5b2a680897c69c238a13cd16b15671f8b73549f"
   integrity sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==
@@ -5418,6 +5940,23 @@ sax@>=0.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.6.0.tgz#da59637629307b97e7c4cb28e080a7bc38560d5b"
   integrity sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==
+
+seed-random@~2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/seed-random/-/seed-random-2.2.0.tgz#2a9b19e250a817099231a5b99a4daf80b7fbed54"
+  integrity sha512-34EQV6AAHQGhoc0tn/96a9Fsi6v2xdqe/dMUwljGRaFOzR3EgRmECvD0O8vi8X+/uQ50LGHfkNu/Eue5TPKZkQ==
+
+"semver@2 || 3 || 4 || 5":
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
+  integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
+
+semver@7.5.3:
+  version "7.5.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.3.tgz#161ce8c2c6b4b3bdca6caadc9fa3317a4c4fe88e"
+  integrity sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==
+  dependencies:
+    lru-cache "^6.0.0"
 
 semver@^6.1.0, semver@^6.3.1:
   version "6.3.1"
@@ -5587,10 +6126,44 @@ source-map-support@0.5.13:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
+source-map-support@0.5.21, source-map-support@^0.5.21:
+  version "0.5.21"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
+  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map@^0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+spdx-correct@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.2.0.tgz#4f5ab0668f0059e34f9c00dce331784a12de4e9c"
+  integrity sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==
+  dependencies:
+    spdx-expression-parse "^3.0.0"
+    spdx-license-ids "^3.0.0"
+
+spdx-exceptions@^2.1.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz#5d607d27fc806f66d7b64a766650fa890f04ed66"
+  integrity sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==
+
+spdx-expression-parse@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz#cf70f50482eefdc98e3ce0a6833e4a53ceeba679"
+  integrity sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==
+  dependencies:
+    spdx-exceptions "^2.1.0"
+    spdx-license-ids "^3.0.0"
+
+spdx-license-ids@^3.0.0:
+  version "3.0.23"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz#b069e687b1291a32f126893ed76a27a745ee2133"
+  integrity sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -5609,6 +6182,11 @@ stack-utils@^2.0.6:
   dependencies:
     escape-string-regexp "^2.0.0"
 
+stackframe@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.3.4.tgz#b881a004c8c149a5e8efef37d51b16e412943310"
+  integrity sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==
+
 statuses@~2.0.1, statuses@~2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.2.tgz#8f75eecef765b5e1cfcdc080da59409ed424e382"
@@ -5626,6 +6204,11 @@ stream-shift@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.3.tgz#85b8fab4d71010fc3ba8772e8046cc49b8a3864b"
   integrity sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==
+
+string-argv@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
+  integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
 
 string-length@^4.0.2:
   version "4.0.2"
@@ -5715,7 +6298,7 @@ string_decoder@~1.1.1:
   dependencies:
     ansi-regex "^5.0.1"
 
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -5801,6 +6384,20 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
 
+thenify-all@^1.0.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/thenify-all/-/thenify-all-1.6.0.tgz#1a1918d402d8fc3f98fbf234db0bcc8cc10e9726"
+  integrity sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==
+  dependencies:
+    thenify ">= 3.1.0 < 4"
+
+"thenify@>= 3.1.0 < 4":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/thenify/-/thenify-3.3.1.tgz#8932e686a4066038a016dd9e2ca46add9838a95f"
+  integrity sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==
+  dependencies:
+    any-promise "^1.0.0"
+
 through@^2.3.7:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
@@ -5811,6 +6408,11 @@ through@~2.2.7:
   resolved "https://registry.yarnpkg.com/through/-/through-2.2.7.tgz#6e8e21200191d4eb6a99f6f010df46aa1c6eb2bd"
   integrity sha512-JIR0m0ybkmTcR8URann+HbwKmodP+OE8UCbsifQDYMLD5J3em1Cdn3MYPpbEd5elGDwmP98T+WbqP/tvzA5Mjg==
 
+tiny-case@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-case/-/tiny-case-1.0.3.tgz#d980d66bc72b5d5a9ca86fb7c9ffdb9c898ddd03"
+  integrity sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==
+
 tinyglobby@^0.2.15:
   version "0.2.16"
   resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.16.tgz#1c3b7eb953fce42b226bc5a1ee06428281aff3d6"
@@ -5818,6 +6420,11 @@ tinyglobby@^0.2.15:
   dependencies:
     fdir "^6.5.0"
     picomatch "^4.0.4"
+
+tmp@0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.3.tgz#eb783cc22bc1e8bebd0671476d46ea4eb32a79ae"
+  integrity sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==
 
 tmpl@1.0.5:
   version "1.0.5"
@@ -5835,6 +6442,11 @@ toidentifier@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
+
+toposort@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
+  integrity sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==
 
 triple-beam@^1.3.0:
   version "1.4.1"
@@ -5856,7 +6468,7 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.4.0:
+tslib@^2.0.3, tslib@^2.4.0:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -5894,6 +6506,26 @@ type-fest@^0.21.3:
   version "0.21.3"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
+
+type-fest@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
+  integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
+
+type-fest@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
+  integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
+type-fest@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
+  integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
+
+type-fest@^4.8.3:
+  version "4.41.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.41.0.tgz#6ae1c8e5731273c2bf1f58ad39cbae2c91a46c58"
+  integrity sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==
 
 type-is@~1.6.18:
   version "1.6.18"
@@ -6025,6 +6657,13 @@ update-browserslist-db@^1.2.3:
     escalade "^3.2.0"
     picocolors "^1.1.1"
 
+upper-case-first@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/upper-case-first/-/upper-case-first-2.0.2.tgz#992c3273f882abd19d1e02894cc147117f844324"
+  integrity sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==
+  dependencies:
+    tslib "^2.0.3"
+
 uri-js@^4.2.2:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
@@ -6044,6 +6683,11 @@ url@0.10.3:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+util-arity@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/util-arity/-/util-arity-1.1.0.tgz#59d01af1fdb3fede0ac4e632b0ab5f6ce97c9330"
+  integrity sha512-kkyIsXKwemfSy8ZEoaIz06ApApnWsk5hQO0vLjZS6UkBiGiW++Jsyb8vSBoc0WKlffGoGs5yYy/j5pp8zckrFA==
 
 util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
@@ -6066,10 +6710,25 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
+uuid@10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-10.0.0.tgz#5a95aa454e6e002725c79055fd42aaba30ca6294"
+  integrity sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==
+
+uuid@11.0.5:
+  version "11.0.5"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.0.5.tgz#07b46bdfa6310c92c3fb3953a8720f170427fc62"
+  integrity sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==
+
 uuid@8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.0.0.tgz#bc6ccf91b5ff0ac07bbcdbf1c7c4e150db4dbb6c"
   integrity sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==
+
+uuid@9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
+  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
 uuid@^8.3.2:
   version "8.3.2"
@@ -6084,6 +6743,14 @@ v8-to-istanbul@^9.0.1:
     "@jridgewell/trace-mapping" "^0.3.12"
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^2.0.0"
+
+validate-npm-package-license@^3.0.1:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
+  integrity sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==
+  dependencies:
+    spdx-correct "^3.0.0"
+    spdx-expression-parse "^3.0.0"
 
 vary@~1.1.2:
   version "1.1.2"
@@ -6255,6 +6922,11 @@ xml2js@0.6.2:
     sax ">=0.6.0"
     xmlbuilder "~11.0.0"
 
+xmlbuilder@15.1.1, xmlbuilder@^15.1.1:
+  version "15.1.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-15.1.1.tgz#9dcdce49eea66d8d10b42cae94a79c3c8d0c2ec5"
+  integrity sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==
+
 xmlbuilder@~11.0.0:
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
@@ -6269,6 +6941,16 @@ yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
+yaml@^2.2.2:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.9.0.tgz#78274afd93598a1dfdd6130df6a566defcbf9aa4"
+  integrity sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==
 
 yargs-parser@^21.1.1:
   version "21.1.1"
@@ -6292,3 +6974,13 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+yup@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-1.2.0.tgz#9e51af0c63bdfc9be0fdc6c10aa0710899d8aff6"
+  integrity sha512-PPqYKSAXjpRCgLgLKVGPA33v5c/WgEx3wi6NFjIiegz90zSwyMpvTFp/uGcVnnbx6to28pgnzp/q8ih3QRjLMQ==
+  dependencies:
+    property-expr "^2.0.5"
+    tiny-case "^1.0.3"
+    toposort "^2.0.2"
+    type-fest "^2.19.0"


### PR DESCRIPTION
## What?
Adds initial Playwright E2E migration coverage for EEC journeys and validation flows.
Updates tests to match current EEC UI changes (removed problem options and updated validation copy).
Improves step stability for navigation/checkbox handling in validation flow
## Why?
EEC Playwright migration and establishes a working baseline.
## How?
Remapped removed problem options to the catch-all route used by current UI.
Updated validation expectations for renamed error messages.
Added resilient summary matching and fallback navigation in step definitions.

## Testing?
Ran targeted migrated scenarios in headed mode after generation:
All tests passed
## Screenshots (optional)

## Anything Else? (optional)

## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
